### PR TITLE
Default socket hint value gets cloned

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile group: 'com.google.inject', name: 'guice', version: '4.0'
     compile group: 'org.python', name: 'jython', version: '2.7.0'
+    compile group: 'uk.com.robust-it', name: 'cloning', version: '1.9.2'
     compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.0'
     compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.0', classifier: "linux-x86"
     compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.0', classifier: "linux-x86_64"

--- a/src/main/java/edu/wpi/grip/core/Socket.java
+++ b/src/main/java/edu/wpi/grip/core/Socket.java
@@ -69,13 +69,19 @@ public class Socket<T> {
     }
 
     /**
-     * @return The value currently stored in this socket.
+     * @return The value currently stored in this socket. If the value in this socket is not yet set it will
+     * set the default value to the value and return it. If unset and no default it will return null.
      */
     public T getValue() {
         if (value.isPresent()) {
-            return value.get();
+            return this.value.get();
+        }
+        T defaultValue = socketHint.getDefaultValue();
+        if(defaultValue == null){
+            return null;
         } else {
-            return socketHint.getDefaultValue();
+            this.setValue(defaultValue);
+            return this.value.get();
         }
     }
 

--- a/src/main/java/edu/wpi/grip/core/SocketHint.java
+++ b/src/main/java/edu/wpi/grip/core/SocketHint.java
@@ -1,6 +1,7 @@
 package edu.wpi.grip.core;
 
 import com.google.common.base.MoreObjects;
+import com.rits.cloning.Cloner;
 
 import java.util.Arrays;
 
@@ -69,7 +70,9 @@ public class SocketHint<T> {
     }
 
     public T getDefaultValue() {
-        return defaultValue;
+        Cloner cloner = new Cloner();
+        //If defaultValue is null library will return null
+        return cloner.deepClone(defaultValue);
     }
 
     @Override


### PR DESCRIPTION
This prevents the original from becoming the reference that all defaults point to.