### PR TITLE
Initialize Python properties in PythonScriptOperation

### DIFF
--- a/src/main/java/edu/wpi/grip/core/operations/PythonScriptOperation.java
+++ b/src/main/java/edu/wpi/grip/core/operations/PythonScriptOperation.java
@@ -11,6 +11,7 @@ import org.python.util.PythonInterpreter;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.Properties;
 
 /**
  * A class that implements an operation using Jython.  This enables users to write plugins for the application as
@@ -41,6 +42,13 @@ import java.util.List;
  * }</pre>
  */
 public class PythonScriptOperation implements Operation {
+
+    static {
+        Properties pythonProperties = new Properties();
+        pythonProperties.setProperty("python.import.site", "false");
+        PySystemState.initialize(pythonProperties, null);
+    }
+
 
     // Either a URL or a String of literal source code is stored in this field.  This allows a PythonScriptOperation to
     // be serialized as a reference to some code rather than trying to save a bunch of Jython internal structures to a

--- a/src/test/java/edu/wpi/grip/core/PythonTest.java
+++ b/src/test/java/edu/wpi/grip/core/PythonTest.java
@@ -3,10 +3,6 @@ package edu.wpi.grip.core;
 import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.operations.PythonScriptOperation;
 import org.junit.Test;
-import org.junit.BeforeClass;
-import org.python.core.PySystemState;
-
-import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -15,13 +11,6 @@ public class PythonTest {
     static final int a = 1234, b = 5678;
 
     EventBus eventBus = new EventBus();
-
-    @BeforeClass
-    public static void setupPythonProperties() {
-        Properties pythonProperties = new Properties();
-        pythonProperties.setProperty("python.import.site", "false");
-        PySystemState.initialize(pythonProperties, null);
-    }
 
     @Test
     public void testPython() throws Exception {


### PR DESCRIPTION
One property needs to be set for Jython to work.  This used to be set in
the python unit test, but to actually use python in the application, we
might as well just set it in a static block in PythonScriptOperation