### PR TITLE
Add SocketHint default values with Suppliers

### DIFF
--- a/src/main/java/edu/wpi/grip/core/Socket.java
+++ b/src/main/java/edu/wpi/grip/core/Socket.java
@@ -24,7 +24,7 @@ public class Socket<T> {
     private Step step;
     private final Set<Connection> connections = new HashSet<>();
     private final SocketHint<T> socketHint;
-    private Optional<T> value;
+    private T value;
     private boolean published = false;
 
     /**
@@ -35,7 +35,7 @@ public class Socket<T> {
     public Socket(EventBus eventBus, SocketHint<T> socketHint, T value) {
         this.eventBus = eventBus;
         this.socketHint = socketHint;
-        this.value = Optional.of(value);
+        this.value = value;
 
         checkNotNull(eventBus);
         checkNotNull(socketHint);
@@ -51,7 +51,7 @@ public class Socket<T> {
     public Socket(EventBus eventBus, SocketHint<T> socketHint) {
         this.eventBus = eventBus;
         this.socketHint = socketHint;
-        this.value = Optional.absent();
+        this.value = socketHint.createInitialValue();
 
         checkNotNull(eventBus);
         checkNotNull(socketHint);
@@ -73,8 +73,8 @@ public class Socket<T> {
      * @param value The value to store in this socket.
      */
     public void setValue(T value) {
-        if (!this.value.isPresent() || !this.value.get().equals(value)) {
-            this.value = Optional.of(this.getSocketHint().getType().cast(value));
+        if (!this.value.equals(value)) {
+            this.value = this.getSocketHint().getType().cast(value);
             eventBus.post(new SocketChangedEvent(this));
 
             // If the socket's value is set to be published, also send a SocketPublishedEvent to notify any sinks that
@@ -89,11 +89,7 @@ public class Socket<T> {
      * @return The value currently stored in this socket.
      */
     public T getValue() {
-        if (value.isPresent()) {
-            return value.get();
-        } else {
-            return socketHint.getDefaultValue();
-        }
+        return this.value;
     }
 
     /**

--- a/src/main/java/edu/wpi/grip/core/SocketHint.java
+++ b/src/main/java/edu/wpi/grip/core/SocketHint.java
@@ -3,6 +3,7 @@ package edu.wpi.grip.core;
 import com.google.common.base.MoreObjects;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 /**
  * A <code>SocketHint</code> is a descriptor that gives some information about one of the inputs or outputs of an
@@ -12,44 +13,47 @@ import java.util.Arrays;
 public class SocketHint<T> {
     public enum View {NONE, SPINNER, SLIDER, RANGE, SELECT}
 
-    private String identifier;
-    private Class<T> type;
-    private View view;
-    private T[] domain;
+    private final String identifier;
+    private final Class<T> type;
+    private final Supplier<T> initialValueSupplier;
+    private final View view;
+    private final T[] domain;
 
     /**
-     * The default value that the socket will hold if no other is specified.
+     * @param identifier           A user-presentable name for the socket, such as "Blur Radius".
+     * @param type                 The type of value held by the socket.
+     * @param view                 A hint at the type of GUI control to use to display the socket.
+     * @param domain               A hint at the range of values that this socket can hold.  For numeric types, this
+     *                             can consist of two elements that correspond to a minimum and maximum value.  The
+     *                             property does not make sense for all types and is left unspecified for some.
+     * @param initialValueSupplier A function that returns an initial value for newly-created sockets.
      */
-    private T defaultValue;
-
-
-    /**
-     * @param identifier   A user-presentable name for the socket, such as "Blur Radius".
-     * @param type         The type of value held by the socket.
-     * @param view         A hint at the type of GUI control to use to display the socket.
-     * @param domain       A hint at the range of values that this socket can hold.  For numeric types, this can consist
-     *                     of two elements that correspond to a minimum and maximum value.  The property does not make
-     *                     sense for all types and is left unspecified for some.
-     * @param defaultValue The value to use in place of the socket's value when none is specified.
-     */
-    public SocketHint(String identifier, Class<T> type, View view, T[] domain, T defaultValue) {
+    public SocketHint(String identifier, Class<T> type, Supplier<T> initialValueSupplier, View view, T[] domain) {
         this.identifier = identifier;
         this.type = type;
+        this.initialValueSupplier = initialValueSupplier;
         this.view = view;
         this.domain = domain == null ? null : domain.clone();
-        this.defaultValue = defaultValue;
     }
 
-    public SocketHint(String identifier, Class<T> type, View view, T[] domain) {
-        this(identifier, type, view, domain, (domain != null && domain.length > 0) ? domain[0] : null);
+    public SocketHint(String identifier, Class<T> type, T initialValue, View view, T[] domain) {
+        this(identifier, type, () -> initialValue, view, domain);
     }
 
-    public SocketHint(String identifier, Class<T> type, View view) {
-        this(identifier, type, view, null);
+    public SocketHint(String identifier, Class<T> type, Supplier<T> initialValueSupplier, View view) {
+        this(identifier, type, initialValueSupplier, view, null);
     }
 
-    public SocketHint(String identifier, Class<T> type) {
-        this(identifier, type, View.NONE);
+    public SocketHint(String identifier, Class<T> type, T initialValue, View view) {
+        this(identifier, type, () -> initialValue, view);
+    }
+
+    public SocketHint(String identifier, Class<T> type, Supplier<T> initialValueSupplier) {
+        this(identifier, type, initialValueSupplier, View.NONE);
+    }
+
+    public SocketHint(String identifier, Class<T> type, T initialValue) {
+        this(identifier, type, () -> initialValue);
     }
 
     public String getIdentifier() {
@@ -68,8 +72,8 @@ public class SocketHint<T> {
         return domain;
     }
 
-    public T getDefaultValue() {
-        return defaultValue;
+    public T createInitialValue() {
+        return initialValueSupplier.get();
     }
 
     @Override
@@ -79,7 +83,6 @@ public class SocketHint<T> {
                 .add("type", getType())
                 .add("view", getView())
                 .add("domain", Arrays.toString(getDomain()))
-                .add("defaultValue", getDefaultValue())
                 .toString();
     }
 }

--- a/src/main/java/edu/wpi/grip/core/operations/PythonScriptOperation.java
+++ b/src/main/java/edu/wpi/grip/core/operations/PythonScriptOperation.java
@@ -139,7 +139,7 @@ public class PythonScriptOperation implements Operation {
      * @return An array of Sockets, based on the global "inputs" list in the Python script
      */
     @Override
-    public Socket<?>[] createInputSockets(EventBus eventBus) {
+    public Socket[] createInputSockets(EventBus eventBus) {
         Socket[] sockets = new Socket[this.inputSocketHints.size()];
 
         for (int i = 0; i < sockets.length; i++) {

--- a/src/main/java/edu/wpi/grip/core/operations/opencv/AddOperation.java
+++ b/src/main/java/edu/wpi/grip/core/operations/opencv/AddOperation.java
@@ -13,9 +13,9 @@ import org.bytedeco.javacpp.opencv_core.*;
  */
 public class AddOperation implements Operation {
     private SocketHint<Mat>
-            aHint = new SocketHint<>("a", Mat.class),
-            bHint = new SocketHint<>("b", Mat.class),
-            sumHint = new SocketHint<>("sum", Mat.class);
+            aHint = new SocketHint<Mat>("a", Mat.class, Mat::new),
+            bHint = new SocketHint<Mat>("b", Mat.class, Mat::new),
+            sumHint = new SocketHint<Mat>("sum", Mat.class, Mat::new);
 
     @Override
     public String getName() {
@@ -28,13 +28,18 @@ public class AddOperation implements Operation {
     }
 
     @Override
-    public Socket<Mat>[] createInputSockets(EventBus eventBus) {
-        return new Socket[]{new Socket<>(eventBus, aHint, new Mat()), new Socket<>(eventBus, bHint, new Mat())};
+    public Socket[] createInputSockets(EventBus eventBus) {
+        return new Socket[]{
+                new Socket<Mat>(eventBus, aHint),
+                new Socket<Mat>(eventBus, bHint)
+        };
     }
 
     @Override
-    public Socket<Mat>[] createOutputSockets(EventBus eventBus) {
-        return new Socket[]{new Socket<>(eventBus, sumHint, new Mat())};
+    public Socket[] createOutputSockets(EventBus eventBus) {
+        return new Socket[]{
+                new Socket<Mat>(eventBus, sumHint)
+        };
     }
 
     @Override

--- a/src/main/java/edu/wpi/grip/core/serialization/PythonScriptOperationConverter.java
+++ b/src/main/java/edu/wpi/grip/core/serialization/PythonScriptOperationConverter.java
@@ -66,6 +66,6 @@ class PythonScriptOperationConverter implements Converter {
      */
     @Override
     public boolean canConvert(Class type) {
-        return type.equals(PythonScriptOperation.class);
+        return PythonScriptOperation.class.equals(type);
     }
 }

--- a/src/main/java/edu/wpi/grip/core/sources/ImageFileSource.java
+++ b/src/main/java/edu/wpi/grip/core/sources/ImageFileSource.java
@@ -16,7 +16,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Provides a way to generate a {@link Mat} from an image on the filesystem.
  */
 public class ImageFileSource implements Source {
-    private final SocketHint imageOutputHint = new SocketHint("Image", Mat.class);
+    private final SocketHint<Mat> imageOutputHint = new SocketHint<Mat>("Image", Mat.class, Mat::new);
     private final Socket<Mat> outputSocket;
 
     /**
@@ -25,7 +25,7 @@ public class ImageFileSource implements Source {
      */
     public ImageFileSource(EventBus eventBus){
         checkNotNull(eventBus, "Event Bus was null.");
-        this.outputSocket = new Socket(eventBus, imageOutputHint);
+        this.outputSocket = new Socket<>(eventBus, imageOutputHint);
     }
 
     @Override

--- a/src/main/java/edu/wpi/grip/ui/controllers/MainWindowController.java
+++ b/src/main/java/edu/wpi/grip/ui/controllers/MainWindowController.java
@@ -40,12 +40,12 @@ public class MainWindowController implements Initializable {
             "description = 'Compute the sum of two numbers using Python'\n" +
 
             "inputs = [\n" +
-            "    grip.SocketHint('a', java.lang.Number, grip.SocketHint.View.SLIDER, [0, 1], 0.1),\n" +
-            "    grip.SocketHint('b', java.lang.Number, grip.SocketHint.View.SLIDER, [0, 1], 0.4),\n" +
+            "    grip.SocketHint('a', java.lang.Number, 0.1, grip.SocketHint.View.SLIDER, [0, 1]),\n" +
+            "    grip.SocketHint('b', java.lang.Number, 0.4, grip.SocketHint.View.SLIDER, [0, 1]),\n" +
             "]\n" +
 
             "outputs = [\n" +
-            "    grip.SocketHint('sum', java.lang.Number),\n" +
+            "    grip.SocketHint('sum', java.lang.Number, 0.0),\n" +
             "]\n" +
 
             "def perform(a, b):\n" +
@@ -60,12 +60,12 @@ public class MainWindowController implements Initializable {
             "description = 'Compute the product of two numbers using Python'\n" +
 
             "inputs = [\n" +
-            "    grip.SocketHint('a', java.lang.Number, grip.SocketHint.View.SLIDER, [0, 1], 0.5),\n" +
-            "    grip.SocketHint('b', java.lang.Number, grip.SocketHint.View.SLIDER, [0, 1], 0.5),\n" +
+            "    grip.SocketHint('a', java.lang.Number, 0.5, grip.SocketHint.View.SLIDER, [0, 1]),\n" +
+            "    grip.SocketHint('b', java.lang.Number, 0.5, grip.SocketHint.View.SLIDER, [0, 1]),\n" +
             "]\n" +
 
             "outputs = [\n" +
-            "    grip.SocketHint('product', java.lang.Number),\n" +
+            "    grip.SocketHint('product', java.lang.Number, 0.0),\n" +
             "]\n" +
 
             "def perform(a, b):\n" +

--- a/src/test/java/edu/wpi/grip/core/AdditionOperation.java
+++ b/src/test/java/edu/wpi/grip/core/AdditionOperation.java
@@ -4,9 +4,9 @@ import com.google.common.eventbus.EventBus;
 
 public class AdditionOperation implements Operation {
     private SocketHint<Double>
-            aHint = new SocketHint<>("a", Double.class, SocketHint.View.NONE, null, 0.0),
-            bHint = new SocketHint<>("b", Double.class, SocketHint.View.NONE, null, 0.0),
-            cHint = new SocketHint<>("b", Double.class, SocketHint.View.NONE, null, 0.0);
+            aHint = new SocketHint<>("a", Double.class, 0.0),
+            bHint = new SocketHint<>("b", Double.class, 0.0),
+            cHint = new SocketHint<>("b", Double.class, 0.0);
 
     @Override
     public String getName() {

--- a/src/test/java/edu/wpi/grip/core/ConnectionTest.java
+++ b/src/test/java/edu/wpi/grip/core/ConnectionTest.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.assertEquals;
 
 public class ConnectionTest {
     EventBus eventBus = new EventBus();
-    SocketHint<Double> fooHint = new SocketHint<>("foo", Double.class, SocketHint.View.NONE, null, 0.0);
-    SocketHint<Double> barHint = new SocketHint<>("bar", Double.class, SocketHint.View.NONE, null, 0.0);
+    SocketHint<Double> fooHint = new SocketHint<>("foo", Double.class, 0.0);
+    SocketHint<Double> barHint = new SocketHint<>("bar", Double.class, 0.0);
     Double testValue = 12345.6789;
 
     @Test

--- a/src/test/java/edu/wpi/grip/core/PythonTest.java
+++ b/src/test/java/edu/wpi/grip/core/PythonTest.java
@@ -29,10 +29,9 @@ public class PythonTest {
     @Test
     public void testPythonAdditionFromString() throws Exception {
         Operation additionFromString = new PythonScriptOperation("import edu.wpi.grip.core as grip\nimport java" +
-                ".lang.Integer\n\ninputs = [\n    grip.SocketHint(\"a\", java.lang.Integer, grip.SocketHint.View.NON" +
-                "E, None, 0),\n    grip.SocketHint(\"b\", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),\n]" +
-                "\n\noutputs = [\n    grip.SocketHint(\"c\", java.lang.Integer),\n]\n\ndef perform(a, b):\n    retur" +
-                "n a + b\n");
+                ".lang.Integer\n\ninputs = [\n    grip.SocketHint(\"a\", java.lang.Integer, 0),\n    grip.SocketHint(" +
+                "\"b\", java.lang.Integer, 0),\n]\n\noutputs = [\n    grip.SocketHint(\"sum\", java.lang.Integer, 0)," +
+                "\n]\n\ndef perform(a, b):\n    return a + b\n");
         Step step = new Step(eventBus, additionFromString);
         Socket aSocket = step.getInputSockets()[0];
         Socket bSocket = step.getInputSockets()[1];
@@ -71,7 +70,7 @@ public class PythonTest {
         aSocket.setValue(a);
         bSocket.setValue(b);
 
-        assertNull(sumSocket.getValue());
+        assertEquals(0, sumSocket.getValue());
     }
 
     @Test
@@ -85,7 +84,7 @@ public class PythonTest {
         aSocket.setValue(a);
         bSocket.setValue(b);
 
-        assertNull(sumSocket.getValue());
+        assertEquals(0, sumSocket.getValue());
     }
 
     @Test

--- a/src/test/java/edu/wpi/grip/core/SinkTest.java
+++ b/src/test/java/edu/wpi/grip/core/SinkTest.java
@@ -31,10 +31,9 @@ public class SinkTest {
         final Pipeline pipeLine = new Pipeline(eventBus);
 
         final Step step = new Step(eventBus, new PythonScriptOperation("import edu.wpi.grip.core as grip\nimport java" +
-                ".lang.Integer\n\ninputs = [\n    grip.SocketHint(\"a\", java.lang.Integer, grip.SocketHint.View.NON" +
-                "E, None, 0),\n    grip.SocketHint(\"b\", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),\n]" +
-                "\n\noutputs = [\n    grip.SocketHint(\"sum\", java.lang.Integer),\n]\n\ndef perform(a, b):\n    retur" +
-                "n a + b\n"));
+                ".lang.Integer\n\ninputs = [\n    grip.SocketHint(\"a\", java.lang.Integer, 0),\n    grip.SocketHint(" +
+                "\"b\", java.lang.Integer, 0),\n]\n\noutputs = [\n    grip.SocketHint(\"sum\", java.lang.Integer, 0)," +
+                "\n]\n\ndef perform(a, b):\n    return a + b\n"));
 
         this.eventBus.post(new StepAddedEvent(step));
 

--- a/src/test/java/edu/wpi/grip/core/SocketTest.java
+++ b/src/test/java/edu/wpi/grip/core/SocketTest.java
@@ -14,7 +14,7 @@ public class SocketTest {
 
     @Test
     public void testGetSocketHint() throws Exception {
-        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, SocketHint.View.SLIDER);
+        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, 0.0, SocketHint.View.SLIDER);
         Socket<Double> socket = new Socket<Double>(eventBus, sh);
 
         assertEquals("foo", socket.getSocketHint().getIdentifier());
@@ -24,7 +24,7 @@ public class SocketTest {
 
     @Test
     public void testSetValue() throws Exception {
-        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, SocketHint.View.SLIDER);
+        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, 0.0, SocketHint.View.SLIDER);
         Socket<Double> socket = new Socket<Double>(eventBus, sh);
 
         socket.setValue(testValue);
@@ -33,7 +33,7 @@ public class SocketTest {
 
     @Test
     public void testDefaultValue() throws Exception {
-        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, SocketHint.View.SLIDER, new Double[0], testValue);
+        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, testValue, SocketHint.View.SLIDER, new Double[0]);
         Socket<Double> socket = new Socket<Double>(eventBus, sh);
 
         assertEquals(testValue, socket.getValue());
@@ -42,7 +42,7 @@ public class SocketTest {
 
     @Test
     public void testSocketChangedEvent() throws Exception {
-        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, SocketHint.View.SLIDER);
+        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, 0.0, SocketHint.View.SLIDER);
         Socket<Double> socket = new Socket<Double>(eventBus, sh);
 
         final boolean[] handled = new boolean[]{false};
@@ -70,14 +70,14 @@ public class SocketTest {
 
     @Test(expected = NullPointerException.class)
     public void testSocketEventBusNotNull() throws Exception {
-        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, SocketHint.View.SLIDER);
+        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, 0.0, SocketHint.View.SLIDER);
         new Socket<Double>(null, sh);
     }
 
     @Test(expected = ClassCastException.class)
     @SuppressWarnings("unchecked")
     public void testSocketValueWrongType() throws Exception {
-        SocketHint<Double> sh = new SocketHint<>("foo", Double.class);
+        SocketHint<Double> sh = new SocketHint<>("foo", Double.class, 0.0);
         Socket socket = new Socket<>(eventBus, sh);
 
         socket.setValue("I am not a Double");

--- a/src/test/java/edu/wpi/grip/core/serialization/SerializationTest.java
+++ b/src/test/java/edu/wpi/grip/core/serialization/SerializationTest.java
@@ -27,11 +27,10 @@ public class SerializationTest {
         additionOperation = new AdditionOperation();
         pythonAdditionOperationFromURL = new PythonScriptOperation(
                 SerializationTest.class.getResource("/edu/wpi/grip/scripts/addition.py"));
-        pythonAdditionOperationFromSource = new PythonScriptOperation("import edu.wpi.grip.core as grip\nimport java" +
-                ".lang.Integer\n\ninputs = [\n    grip.SocketHint(\"a\", java.lang.Integer, grip.SocketHint.View.NON" +
-                "E, None, 0),\n    grip.SocketHint(\"b\", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),\n]" +
-                "\n\noutputs = [\n    grip.SocketHint(\"c\", java.lang.Integer),\n]\n\ndef perform(a, b):\n    retur" +
-                "n a + b\n");
+        pythonAdditionOperationFromSource =  new PythonScriptOperation("import edu.wpi.grip.core as grip\nimport java" +
+                ".lang.Integer\n\ninputs = [\n    grip.SocketHint(\"a\", java.lang.Integer, 0),\n    grip.SocketHint(" +
+                "\"b\", java.lang.Integer, 0),\n]\n\noutputs = [\n    grip.SocketHint(\"sum\", java.lang.Integer, 0)," +
+                "\n]\n\ndef perform(a, b):\n    return a + b\n");
     }
 
     private Pipeline serializeAndDeserialize(Pipeline pipeline) {

--- a/src/test/java/edu/wpi/grip/core/sources/ImageFileSourceTest.java
+++ b/src/test/java/edu/wpi/grip/core/sources/ImageFileSourceTest.java
@@ -45,13 +45,13 @@ public class ImageFileSourceTest {
     public void testReadInTextFile(){
         fileSource.loadImage(textUrl);
         Socket<Mat> outputSocket = fileSource.getOutputSockets()[0];
-        assertNull("No matrix should have been returned.", outputSocket.getValue());
+        assertTrue("No matrix should have been returned.", outputSocket.getValue().empty());
     }
 
     @Test
     public void testReadInFileWithoutExtention() throws MalformedURLException {
         fileSource.loadImage(new URL("file://temp/fdkajdl3eaf"));
         Socket<Mat> outputSocket = fileSource.getOutputSockets()[0];
-        assertNull("No matrix should have been returned.", outputSocket.getValue());
+        assertTrue("No matrix should have been returned.", outputSocket.getValue().empty());
     }
 }

--- a/src/test/resources/edu/wpi/grip/scripts/addition-subtraction.py
+++ b/src/test/resources/edu/wpi/grip/scripts/addition-subtraction.py
@@ -2,13 +2,13 @@ import edu.wpi.grip.core as grip
 import java.lang.Integer
 
 inputs = [
-    grip.SocketHint("a", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
-    grip.SocketHint("b", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
+    grip.SocketHint("a", java.lang.Integer, 0),
+    grip.SocketHint("b", java.lang.Integer, 0),
 ]
 
 outputs = [
-    grip.SocketHint("sum", java.lang.Integer),
-    grip.SocketHint("difference", java.lang.Integer),
+    grip.SocketHint("sum", java.lang.Integer, 0),
+    grip.SocketHint("difference", java.lang.Integer, 0),
 ]
 
 def perform(a, b):

--- a/src/test/resources/edu/wpi/grip/scripts/addition-with-name-and-description.py
+++ b/src/test/resources/edu/wpi/grip/scripts/addition-with-name-and-description.py
@@ -6,12 +6,12 @@ name = "Add"
 description = "Compute the sum of two integers"
 
 inputs = [
-    grip.SocketHint("a", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
-    grip.SocketHint("b", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
+    grip.SocketHint("a", java.lang.Integer, 0),
+    grip.SocketHint("b", java.lang.Integer, 0),
 ]
 
 outputs = [
-    grip.SocketHint("sum", java.lang.Integer),
+    grip.SocketHint("sum", java.lang.Integer, 0),
 ]
 
 def perform(a, b):

--- a/src/test/resources/edu/wpi/grip/scripts/addition-wrong-output-count.py
+++ b/src/test/resources/edu/wpi/grip/scripts/addition-wrong-output-count.py
@@ -2,12 +2,12 @@ import edu.wpi.grip.core as grip
 import java.lang.Integer
 
 inputs = [
-    grip.SocketHint("a", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
-    grip.SocketHint("b", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
+    grip.SocketHint("a", java.lang.Integer, 0),
+    grip.SocketHint("b", java.lang.Integer, 0),
 ]
 
 outputs = [
-    grip.SocketHint("sum", java.lang.Integer),
+    grip.SocketHint("sum", java.lang.Integer, 0),
 ]
 
 def perform(a, b):

--- a/src/test/resources/edu/wpi/grip/scripts/addition-wrong-output-type.py
+++ b/src/test/resources/edu/wpi/grip/scripts/addition-wrong-output-type.py
@@ -2,12 +2,12 @@ import edu.wpi.grip.core as grip
 import java.lang.Integer
 
 inputs = [
-    grip.SocketHint("a", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
-    grip.SocketHint("b", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
+    grip.SocketHint("a", java.lang.Integer, 0),
+    grip.SocketHint("b", java.lang.Integer, 0),
 ]
 
 outputs = [
-    grip.SocketHint("sum", java.lang.Integer),
+    grip.SocketHint("sum", java.lang.Integer, 0),
 ]
 
 def perform(a, b):

--- a/src/test/resources/edu/wpi/grip/scripts/addition.py
+++ b/src/test/resources/edu/wpi/grip/scripts/addition.py
@@ -2,12 +2,12 @@ import edu.wpi.grip.core as grip
 import java.lang.Integer
 
 inputs = [
-    grip.SocketHint("a", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
-    grip.SocketHint("b", java.lang.Integer, grip.SocketHint.View.NONE, None, 0),
+    grip.SocketHint("a", java.lang.Integer, 0),
+    grip.SocketHint("b", java.lang.Integer, 0),
 ]
 
 outputs = [
-    grip.SocketHint("sum", java.lang.Integer),
+    grip.SocketHint("sum", java.lang.Integer, 0),
 ]
 
 def perform(a, b):


### PR DESCRIPTION
Instead of specifying a default value for sockets where no other value
is set, you can specify a function that returns an initial value for any
socket that isn't initialized with a value.  This ensures that all
sockets have a value, and also that those values can each be a new
instance (for mutable types like Mat).

For example, to make every socket have 5 as an initial value:

    sh = new SocketHint<>("my-socket", Integer.class, 5);

But to make every socket construct a new Mat as an initial value (so
they don't all share the same instance):

    sh = new SocketHint<>("my-socket", Mat.class, Mat::new);

When constructing the sockets themselves, it's not necessary to specify a
default value, but that constructor is still there in case you want to
immediately set a value other than the initial one from the socket hint.