### PR TITLE
Add a getDirection() method to sockets to distinguish inputs/outputs

### DIFF
--- a/src/main/java/edu/wpi/grip/core/Connection.java
+++ b/src/main/java/edu/wpi/grip/core/Connection.java
@@ -6,6 +6,7 @@ import edu.wpi.grip.core.events.ConnectionRemovedEvent;
 import edu.wpi.grip.core.events.SocketChangedEvent;
 import edu.wpi.grip.core.events.StepRemovedEvent;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -29,6 +30,10 @@ public class Connection<T> {
         checkNotNull(inputSocket);
         checkNotNull(outputSocket);
         checkNotNull(eventBus);
+        checkArgument(!Socket.Direction.INPUT.equals(outputSocket.getDirection()),
+                "outputSocket cannot be an input socket");
+        checkArgument(!Socket.Direction.OUTPUT.equals(inputSocket.getDirection()),
+                "inputSocket cannot be an output socket");
 
         if (inputSocket == outputSocket) {
             throw new IllegalArgumentException("inputSocket cannot be the same as outputSocket");

--- a/src/main/java/edu/wpi/grip/core/Socket.java
+++ b/src/main/java/edu/wpi/grip/core/Socket.java
@@ -15,13 +15,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A socket is a wrapper for a value that can be updated and passed around operations.  Sockets contain a set of hints
  * about the data they contain, as well as an actual value.
- * <p/>
+ * <p>
  * Sockets that are given to operations are referred to as "input sockets", and sockets that operations store their
  * results in are referred to as "output sockets".
  */
 public class Socket<T> {
+    public enum Direction {INPUT, OUTPUT}
+
     private final EventBus eventBus;
     private Step step;
+    private Direction direction;
     private final Set<Connection> connections = new HashSet<>();
     private final SocketHint<T> socketHint;
     private T value;
@@ -36,6 +39,7 @@ public class Socket<T> {
         this.eventBus = eventBus;
         this.socketHint = socketHint;
         this.value = value;
+        this.direction = Direction.INPUT;
 
         checkNotNull(eventBus);
         checkNotNull(socketHint);
@@ -52,6 +56,7 @@ public class Socket<T> {
         this.eventBus = eventBus;
         this.socketHint = socketHint;
         this.value = socketHint.createInitialValue();
+        this.direction = Direction.INPUT;
 
         checkNotNull(eventBus);
         checkNotNull(socketHint);
@@ -104,6 +109,24 @@ public class Socket<T> {
      */
     public Step getStep() {
         return step;
+    }
+
+
+    /**
+     * @param direction <code>INPUT</code> if this is the input to a step or sink, <code>OUTPUT</code> if this is the
+     *                  output of a step or source
+     */
+    public void setDirection(Direction direction) {
+        checkNotNull(direction);
+        this.direction = direction;
+    }
+
+    /**
+     * @return <code>INPUT</code> if this is the input to a step or sink, <code>OUTPUT</code> if this is the output of
+     * a step or source
+     */
+    public Direction getDirection() {
+        return this.direction;
     }
 
     /**

--- a/src/main/java/edu/wpi/grip/core/Step.java
+++ b/src/main/java/edu/wpi/grip/core/Step.java
@@ -29,11 +29,13 @@ public class Step {
         inputSockets = operation.createInputSockets(eventBus);
         for (Socket<?> socket : inputSockets) {
             socket.setStep(this);
+            socket.setDirection(Socket.Direction.INPUT);
         }
 
         outputSockets = operation.createOutputSockets(eventBus);
         for (Socket<?> socket : outputSockets) {
             socket.setStep(this);
+            socket.setDirection(Socket.Direction.OUTPUT);
         }
 
         operation.perform(inputSockets, outputSockets);

--- a/src/main/java/edu/wpi/grip/core/sources/ImageFileSource.java
+++ b/src/main/java/edu/wpi/grip/core/sources/ImageFileSource.java
@@ -26,6 +26,7 @@ public class ImageFileSource implements Source {
     public ImageFileSource(EventBus eventBus){
         checkNotNull(eventBus, "Event Bus was null.");
         this.outputSocket = new Socket<>(eventBus, imageOutputHint);
+        this.outputSocket.setDirection(Socket.Direction.OUTPUT);
     }
 
     @Override

--- a/src/test/java/edu/wpi/grip/core/ConnectionTest.java
+++ b/src/test/java/edu/wpi/grip/core/ConnectionTest.java
@@ -14,7 +14,11 @@ public class ConnectionTest {
     @Test
     public void testInputSocketChanges() {
         Socket<Double> foo = new Socket<>(eventBus, fooHint);
+        foo.setDirection(Socket.Direction.OUTPUT);
+
         Socket<Double> bar = new Socket<>(eventBus, barHint);
+        bar.setDirection(Socket.Direction.INPUT);
+
         Connection<Double> connection = new Connection<>(eventBus, foo, bar);
 
         foo.setValue(testValue);
@@ -46,5 +50,16 @@ public class ConnectionTest {
     public void testInputSocketNotNull() {
         Socket<Double> foo = new Socket<>(eventBus, fooHint);
         Connection<Double> connection = new Connection<>(eventBus, foo, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBackwardsConnection() {
+        Socket<Double> output = new Socket<>(eventBus, fooHint);
+        output.setDirection(Socket.Direction.OUTPUT);
+
+        Socket<Double> input= new Socket<>(eventBus, fooHint);
+        input.setDirection(Socket.Direction.INPUT);
+
+        new Connection<Double>(eventBus, input, output);
     }
 }

--- a/src/test/java/edu/wpi/grip/core/StepTest.java
+++ b/src/test/java/edu/wpi/grip/core/StepTest.java
@@ -34,6 +34,18 @@ public class StepTest {
     }
 
     @Test
+    public void testSocketDirection() {
+        Step step = new Step(eventBus, addition);
+        Socket<Double> a = (Socket<Double>) step.getInputSockets()[0];
+        Socket<Double> b = (Socket<Double>) step.getInputSockets()[1];
+        Socket<Double> c = (Socket<Double>) step.getOutputSockets()[0];
+
+        assertEquals(Socket.Direction.INPUT, a.getDirection());
+        assertEquals(Socket.Direction.INPUT, b.getDirection());
+        assertEquals(Socket.Direction.OUTPUT, c.getDirection());
+    }
+
+    @Test
     public void testGetOperation() {
         Step step = new Step(eventBus, addition);
 


### PR DESCRIPTION
This can be used by the GUI to validate some user input, and also to
make it easier and cleaner to add specific things to the input and
output JavaFX controls (like options to preview outputs)

Basically, `Step` (as well as any other class that creates sockets) is
responsible for setting a direction on the socket after creating it.  By not
putting it in SocketHint, we avoid a ton of redundant boilerplate code in
every single operation and python script, and we also don't break
our existing code.