### PR TITLE
Don't try to be clever about not sending SocketChangedEvents

### DIFF
--- a/src/main/java/edu/wpi/grip/core/OutputSocket.java
+++ b/src/main/java/edu/wpi/grip/core/OutputSocket.java
@@ -9,6 +9,7 @@ import edu.wpi.grip.core.events.SocketPublishedEvent;
 /**
  * Represents the output of an {@link Operation}. The OutputSocket also provides the ability to
  * make the value in a socket published.
+ *
  * @param <T> The type of the value that this socket stores.
  */
 public class OutputSocket<T> extends Socket<T> {
@@ -35,23 +36,18 @@ public class OutputSocket<T> extends Socket<T> {
      * @param eventBus   The Guava {@link EventBus} used by the application.
      * @param socketHint {@link #getSocketHint}
      */
-    public OutputSocket(EventBus eventBus, SocketHint<T> socketHint){
+    public OutputSocket(EventBus eventBus, SocketHint<T> socketHint) {
         super(eventBus, socketHint, Direction.OUTPUT);
     }
 
     @Override
-    public void setValue(T value){
-        // Check equality first before the value is ste
-        final boolean isNewValue = !this.getValue().equals(value);
-        // Set the value now that we know if there is a new value being stored
+    public void setValue(T value) {
         super.setValue(value);
-        // Now that the value is stored then publish the event
-        if (isNewValue) {
-            // If the socket's value is set to be published, also send a SocketPublishedEvent to notify any sinks that
-            // it has changed.
-            if (this.isPublished()) {
-                eventBus.post(new SocketPublishedEvent(this));
-            }
+
+        // If the socket's value is set to be published, also send a SocketPublishedEvent to notify any sinks that
+        // it has changed.
+        if (this.isPublished()) {
+            eventBus.post(new SocketPublishedEvent(this));
         }
     }
 
@@ -106,7 +102,7 @@ public class OutputSocket<T> extends Socket<T> {
 
 
     @Override
-    public String toString(){
+    public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("socketHint", getSocketHint())
                 .add("value", getValue())

--- a/src/main/java/edu/wpi/grip/core/Socket.java
+++ b/src/main/java/edu/wpi/grip/core/Socket.java
@@ -75,16 +75,13 @@ public abstract class Socket<T> {
     }
 
     /**
-     * Set the value of the socket, and fire off a {@link edu.wpi.grip.core.events.SocketChangedEvent} if the value is
-     * different from the current one.
+     * Set the value of the socket, and fire off a {@link edu.wpi.grip.core.events.SocketChangedEvent}.
      *
      * @param value The value to store in this socket.
      */
     public void setValue(T value) {
-        if (!this.value.equals(value)) {
-            this.value = this.getSocketHint().getType().cast(value);
-            eventBus.post(new SocketChangedEvent(this));
-        }
+        this.value = this.getSocketHint().getType().cast(value);
+        eventBus.post(new SocketChangedEvent(this));
     }
 
     /**

--- a/src/main/java/edu/wpi/grip/core/Step.java
+++ b/src/main/java/edu/wpi/grip/core/Step.java
@@ -64,9 +64,11 @@ public class Step {
 
     @Subscribe
     public void onInputSocketChanged(SocketChangedEvent e) {
+        final Socket socket = e.getSocket();
+
         // If this socket that changed is one of the inputs to this step, run the operation with the new value.
-        if (e.getSocket().getStep() == this) {
-            operation.perform(inputSockets, outputSockets);
+        if (socket.getStep() == this && socket.getDirection().equals(Socket.Direction.INPUT)) {
+            this.operation.perform(inputSockets, outputSockets);
         }
     }
 }


### PR DESCRIPTION
In Socket::setValue(), it doesn't really make sense to not send a
SocketChangedEvent if the new value is equal to the old value, since
some types (like Mat) can actually be modified in-place.

Since the "optimization" of not sending events doesn't really come up in
practice anywhere intentional, it's better just to remove this check.

For this to not break everything, we have to make sure that steps only
update if one of their inputs changes, not if *any* of their sockets
changes.  It should probably be like this anyways, because otherwise
we're running twice as many operations as we need to.