### PR TITLE
Fix previews to work with opencv functions

### DIFF
--- a/src/main/java/edu/wpi/grip/ui/preview/SocketPreviewView.java
+++ b/src/main/java/edu/wpi/grip/ui/preview/SocketPreviewView.java
@@ -1,14 +1,9 @@
 package edu.wpi.grip.ui.preview;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
-import edu.wpi.grip.core.Socket;
-import edu.wpi.grip.core.events.SocketChangedEvent;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
+import edu.wpi.grip.core.OutputSocket;
 import javafx.scene.control.TitledPane;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -17,21 +12,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public abstract class SocketPreviewView<T> extends TitledPane {
     private final EventBus eventBus;
-    private final Socket<T> socket;
-    private final ObjectProperty<T> valueProperty;
+    private final OutputSocket<T> socket;
 
     /**
      * @param eventBus The EventBus used by the application
      * @param socket   An output socket to preview
      */
-    public SocketPreviewView(EventBus eventBus, Socket<T> socket) {
+    public SocketPreviewView(EventBus eventBus, OutputSocket<T> socket) {
         checkNotNull(eventBus);
         checkNotNull(socket);
-        checkArgument(socket.getDirection() == Socket.Direction.OUTPUT);
 
         this.eventBus = eventBus;
         this.socket = socket;
-        this.valueProperty = new SimpleObjectProperty<>(this, "value", socket.getValue());
 
         this.eventBus.register(this);
 
@@ -40,22 +32,7 @@ public abstract class SocketPreviewView<T> extends TitledPane {
         this.setCollapsible(false);
     }
 
-    public Socket<T> getSocket() {
+    public OutputSocket<T> getSocket() {
         return this.socket;
-    }
-
-    /**
-     * The value of the socket being previewed.  Subclasses bind this to some visible property to show the user what
-     * the value of the socket is.
-     */
-    public ObjectProperty<T> valueProperty() {
-        return this.valueProperty;
-    }
-
-    @Subscribe
-    public void onSocketChanged(SocketChangedEvent event) {
-        if (event.getSocket() == this.socket) {
-            this.valueProperty.set(this.socket.getValue());
-        }
     }
 }

--- a/src/main/java/edu/wpi/grip/ui/preview/SocketPreviewViewFactory.java
+++ b/src/main/java/edu/wpi/grip/ui/preview/SocketPreviewViewFactory.java
@@ -1,7 +1,7 @@
 package edu.wpi.grip.ui.preview;
 
 import com.google.common.eventbus.EventBus;
-import edu.wpi.grip.core.Socket;
+import edu.wpi.grip.core.OutputSocket;
 
 import static org.bytedeco.javacpp.opencv_core.Mat;
 
@@ -16,9 +16,9 @@ public class SocketPreviewViewFactory {
      * out what control to use to render a given socket.
      */
     @SuppressWarnings("unchecked")
-    public static <T> SocketPreviewView<T> createPreviewView(EventBus eventBus, Socket<T> socket) {
+    public static <T> SocketPreviewView<T> createPreviewView(EventBus eventBus, OutputSocket<T> socket) {
         if (socket.getSocketHint().getType() == Mat.class) {
-            return (SocketPreviewView) new ImageSocketPreviewView(eventBus, (Socket<Mat>) socket);
+            return (SocketPreviewView) new ImageSocketPreviewView(eventBus, (OutputSocket<Mat>) socket);
         } else {
             return new TextAreaSocketPreviewView<>(eventBus, socket);
         }

--- a/src/main/java/edu/wpi/grip/ui/preview/TextAreaSocketPreviewView.java
+++ b/src/main/java/edu/wpi/grip/ui/preview/TextAreaSocketPreviewView.java
@@ -1,7 +1,10 @@
 package edu.wpi.grip.ui.preview;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import edu.wpi.grip.core.OutputSocket;
 import edu.wpi.grip.core.Socket;
+import edu.wpi.grip.core.events.SocketChangedEvent;
 import javafx.scene.control.TextArea;
 
 /**
@@ -10,19 +13,29 @@ import javafx.scene.control.TextArea;
  */
 public class TextAreaSocketPreviewView<T> extends SocketPreviewView<T> {
 
+    final TextArea text;
+
     /**
      * @param eventBus The EventBus used by the application
      * @param socket   An output socket to preview
      */
-    public TextAreaSocketPreviewView(EventBus eventBus, Socket<T> socket) {
+    public TextAreaSocketPreviewView(EventBus eventBus, OutputSocket<T> socket) {
         super(eventBus, socket);
 
         this.setStyle("-fx-pref-width: 20em;");
 
-        final TextArea text = new TextArea(this.valueProperty().asString().get());
+        this.text = new TextArea(socket.getValue().toString());
         text.setEditable(false);
-        text.textProperty().bind(this.valueProperty().asString());
 
         this.setContent(text);
+    }
+
+    @Subscribe
+    public void onSocketChanged(SocketChangedEvent event) {
+        final Socket socket = event.getSocket();
+
+        if (socket == this.getSocket()) {
+            this.text.setText(socket.getValue().toString());
+        }
     }
 }


### PR DESCRIPTION
This fixes several issues with socket previews that came up when
integrating opencv functions

- They should only take `OutputSocket`s
- They should not rely on JavaFX properties to know when sockets change
- Image previews should not attempt to render empty images (we might
  want to make a placeholder image eventually)