### PR TITLE
Only make sockets publishable if their socket hint says so

### DIFF
--- a/src/main/java/edu/wpi/grip/core/OutputSocket.java
+++ b/src/main/java/edu/wpi/grip/core/OutputSocket.java
@@ -6,6 +6,10 @@ import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.events.SocketPreviewChangedEvent;
 import edu.wpi.grip.core.events.SocketPublishedEvent;
 
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Represents the output of an {@link Operation}. The OutputSocket also provides the ability to
  * make the value in a socket published.
@@ -53,9 +57,12 @@ public class OutputSocket<T> extends Socket<T> {
 
     /**
      * @param published If <code>true</code>, this socket will be published by any sink that is currently active.  For
-     *                  example, it may be set as a NetworkTables value.
+     *                  example, it may be set as a NetworkTables value.  The socket must be publishable.
+     * @see SocketHint#SocketHint(String, Class, Supplier, SocketHint.View, Object[], boolean)
      */
     public void setPublished(boolean published) {
+        checkArgument(this.getSocketHint().isPublishable() || !published, "socket is not publishable");
+
         /* Check if this value is changing */
         final boolean change = isPublished() != published;
         /* Save whether it was published before. */

--- a/src/main/java/edu/wpi/grip/core/SocketHint.java
+++ b/src/main/java/edu/wpi/grip/core/SocketHint.java
@@ -18,6 +18,7 @@ public class SocketHint<T> {
     private final Supplier<T> initialValueSupplier;
     private final View view;
     private final T[] domain;
+    private boolean publishable;
 
     /**
      * @param identifier           A user-presentable name for the socket, such as "Blur Radius".
@@ -27,13 +28,25 @@ public class SocketHint<T> {
      *                             can consist of two elements that correspond to a minimum and maximum value.  The
      *                             property does not make sense for all types and is left unspecified for some.
      * @param initialValueSupplier A function that returns an initial value for newly-created sockets.
+     * @param publishable          If this isn't true, the socket won't be able to be set as published, and the GUI
+     *                             should also not show a button to publish it.  This is false by default.
      */
-    public SocketHint(String identifier, Class<T> type, Supplier<T> initialValueSupplier, View view, T[] domain) {
+    public SocketHint(String identifier, Class<T> type, Supplier<T> initialValueSupplier, View view, T[] domain,
+                      boolean publishable) {
         this.identifier = identifier;
         this.type = type;
         this.initialValueSupplier = initialValueSupplier;
         this.view = view;
         this.domain = domain == null ? null : domain.clone();
+        this.publishable = publishable;
+    }
+
+    public SocketHint(String identifier, Class<T> type, T initialValue, View view, T[] domain, boolean publishable) {
+        this(identifier, type, () -> initialValue, view, domain, publishable);
+    }
+
+    public SocketHint(String identifier, Class<T> type, Supplier<T> initialValueSupplier, View view, T[] domain) {
+        this(identifier, type, initialValueSupplier, view, domain, false);
     }
 
     public SocketHint(String identifier, Class<T> type, T initialValue, View view, T[] domain) {
@@ -70,6 +83,10 @@ public class SocketHint<T> {
 
     public T[] getDomain() {
         return domain;
+    }
+
+    public boolean isPublishable() {
+        return this.publishable;
     }
 
     public T createInitialValue() {

--- a/src/main/java/edu/wpi/grip/ui/controllers/MainWindowController.java
+++ b/src/main/java/edu/wpi/grip/ui/controllers/MainWindowController.java
@@ -46,7 +46,7 @@ public class MainWindowController implements Initializable {
             "]\n" +
 
             "outputs = [\n" +
-            "    grip.SocketHint('sum', java.lang.Number, 0.0),\n" +
+            "    grip.SocketHint('sum', java.lang.Number, 0.0, grip.SocketHint.View.NONE, None, True),\n" +
             "]\n" +
 
             "def perform(a, b):\n" +
@@ -66,7 +66,7 @@ public class MainWindowController implements Initializable {
             "]\n" +
 
             "outputs = [\n" +
-            "    grip.SocketHint('product', java.lang.Number, 0.0),\n" +
+            "    grip.SocketHint('product', java.lang.Number, 0.0, grip.SocketHint.View.NONE, None, True),\n" +
             "]\n" +
 
             "def perform(a, b):\n" +

--- a/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketView.java
@@ -70,9 +70,13 @@ public class OutputSocketView extends HBox implements Initializable {
 
         this.handlePane.getChildren().add(this.handle);
 
-        // Show a button to publish the output to the current sink
-        this.publish.setSelected(this.socket.isPublished());
-        this.publish.selectedProperty().addListener(value -> this.socket.setPublished(this.publish.isSelected()));
+        // Show a button to publish the output to the current sink, if the socket is publishable
+        if (this.socket.getSocketHint().isPublishable()) {
+            this.publish.setSelected(this.socket.isPublished());
+            this.publish.selectedProperty().addListener(value -> this.socket.setPublished(this.publish.isSelected()));
+        } else {
+            this.getChildren().remove(this.publish);
+        }
 
         // Show a button to choose if we want to preview the socket or not
         this.preview.setSelected(this.socket.isPreviewed());

--- a/src/test/java/edu/wpi/grip/core/SinkTest.java
+++ b/src/test/java/edu/wpi/grip/core/SinkTest.java
@@ -31,10 +31,17 @@ public class SinkTest {
     public void createSimplePipeline() {
         final Pipeline pipeLine = new Pipeline(eventBus);
 
-        final Step step = new Step(eventBus, new PythonScriptOperation("import edu.wpi.grip.core as grip\nimport java" +
-                ".lang.Integer\n\ninputs = [\n    grip.SocketHint(\"a\", java.lang.Integer, 0),\n    grip.SocketHint(" +
-                "\"b\", java.lang.Integer, 0),\n]\n\noutputs = [\n    grip.SocketHint(\"sum\", java.lang.Integer, 0)," +
-                "\n]\n\ndef perform(a, b):\n    return a + b\n"));
+        final Step step = new Step(eventBus, new PythonScriptOperation(
+                "import edu.wpi.grip.core as grip\n" +
+                "import java.lang.Number\n" +
+                "inputs = [\n" +
+                "    grip.SocketHint('a', java.lang.Number, 0),\n" +
+                "    grip.SocketHint('b', java.lang.Number, 0),\n" +
+                "]\n" +
+                "outputs = [\n" +
+                "    grip.SocketHint('sum', java.lang.Number, 0.0, grip.SocketHint.View.NONE, None, True),\n" +
+                "]\n" +
+                "def perform(a, b): return a + b\n"));
 
         this.eventBus.post(new StepAddedEvent(step));
 

--- a/src/test/java/edu/wpi/grip/core/SocketTest.java
+++ b/src/test/java/edu/wpi/grip/core/SocketTest.java
@@ -112,4 +112,12 @@ public class SocketTest {
 
         socket.setValue("I am not a Double");
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNotPublishableSocket() throws Exception {
+        final SocketHint<Double> sh = new SocketHint<>("foo", Double.class, 0.0);
+        final OutputSocket<Double> socket = new OutputSocket<Double>(eventBus, sh);
+
+        socket.setPublished(true);
+    }
 }


### PR DESCRIPTION
This adds a "publishable" field to SocketHint that controls if a socket
can be set to be published to a sink.  It doesn't make sense for a lot
of sockets to be able to be published

Not preventing it would create confusion (mats would likely be published
somewhere as the result of Mat::toString(), which is almost certainly
not was the user things).  Plus, the publish buttons create visual
clutter.

Since the default setting is `false`, we should make sure that anything
that could be published is set as publishable.  This probably means
manually tagging certain opencv output parameters as publishable.