### PR TITLE
Make the connection curves slightly nicer

### DIFF
--- a/src/main/java/edu/wpi/grip/ui/pipeline/ConnectionView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/ConnectionView.java
@@ -34,18 +34,19 @@ public class ConnectionView extends CubicCurve {
         this.setStroke(STROKE);
         this.setStrokeWidth(2.0);
 
+        this.controlX1Property().bind(this.startXProperty().add(this.endXProperty()).multiply(0.5));
+        this.controlY1Property().bind(this.startYProperty());
+        this.controlX2Property().bind(this.controlX1Property());
+        this.controlY2Property().bind(this.endYProperty());
+
         this.outputHandleProperty().addListener(observable -> {
             this.setStartX(this.outputHandle.get().getX());
             this.setStartY(this.outputHandle.get().getY());
-            this.setControlY1(this.outputHandle.get().getY());
-            this.setControlX2(this.outputHandle.get().getX());
         });
 
         this.inputHandleProperty().addListener(observable -> {
             this.setEndX(this.inputHandle.get().getX());
             this.setEndY(this.inputHandle.get().getY());
-            this.setControlY2(this.inputHandle.get().getY());
-            this.setControlX1(this.inputHandle.get().getX());
         });
 
         this.eventBus.register(this);


### PR DESCRIPTION
Connections are rendered as a cubic curve.  This change adjusts the
positions of the control points so they are influenced by the positions
of both sockets.  Blender's node editor seems to use the same algorithm.

![](https://cloud.githubusercontent.com/assets/3964980/10414541/095bd7ba-6fa8-11e5-82d7-69abe8d5ca99.gif)