### PR TITLE
Fix paths for ImageFileSource to be OS-independant

### DIFF
--- a/src/main/java/edu/wpi/grip/ui/pipeline/AddSourceView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/AddSourceView.java
@@ -7,7 +7,6 @@ import edu.wpi.grip.core.sources.WebcamSource;
 import javafx.event.EventHandler;
 import javafx.scene.Parent;
 import javafx.scene.control.*;
-import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
@@ -16,12 +15,12 @@ import javafx.stage.FileChooser;
 import javafx.stage.Screen;
 
 import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.function.Predicate;
 
 /**
@@ -62,12 +61,7 @@ public class AddSourceView extends HBox {
             // Add a new source for each image .
             imageFiles.forEach(file -> {
                 this.loadSourceExecutor.execute(() -> {
-                    try {
-                        final ImageFileSource source = new ImageFileSource(eventBus, file.toURI().toURL());
-                        eventBus.post(new SourceAddedEvent(source));
-                    } catch (MalformedURLException e) {
-                        e.printStackTrace();
-                    }
+                    eventBus.post(new SourceAddedEvent(new ImageFileSource(eventBus, file)));
                 });
             });
         });

--- a/src/test/java/edu/wpi/grip/core/PipelineTest.java
+++ b/src/test/java/edu/wpi/grip/core/PipelineTest.java
@@ -5,19 +5,22 @@ import edu.wpi.grip.core.events.*;
 import edu.wpi.grip.core.sources.ImageFileSource;
 import org.junit.Test;
 
+import java.io.File;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PipelineTest {
     EventBus eventBus = new EventBus();
     Operation addition = new AdditionOperation();
 
     @Test
-    public void testAddSource() {
+    public void testAddSource() throws URISyntaxException {
         Pipeline pipeline = new Pipeline(eventBus);
-        Source source = new ImageFileSource(eventBus, getClass().getResource("/edu/wpi/grip/images/GRIP_Logo.png"));
+        Source source = new ImageFileSource(eventBus, new File(getClass().getResource("/edu/wpi/grip/images/GRIP_Logo.png").toURI()));
 
         eventBus.post(new SourceAddedEvent(source));
 
@@ -25,9 +28,9 @@ public class PipelineTest {
     }
 
     @Test
-    public void testRemoveSource() {
+    public void testRemoveSource() throws URISyntaxException {
         Pipeline pipeline = new Pipeline(eventBus);
-        Source source = new ImageFileSource(eventBus, getClass().getResource("/edu/wpi/grip/images/GRIP_Logo.png"));
+        Source source = new ImageFileSource(eventBus, new File(getClass().getResource("/edu/wpi/grip/images/GRIP_Logo.png").toURI()));
 
         eventBus.post(new SourceAddedEvent(source));
         eventBus.post(new SourceRemovedEvent(source));

--- a/src/test/java/edu/wpi/grip/core/sources/ImageFileSourceTest.java
+++ b/src/test/java/edu/wpi/grip/core/sources/ImageFileSourceTest.java
@@ -6,8 +6,9 @@ import org.bytedeco.javacpp.opencv_core.Mat;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URISyntaxException;
 
 import static org.junit.Assert.*;
 
@@ -15,20 +16,22 @@ import static org.junit.Assert.*;
  *
  */
 public class ImageFileSourceTest {
-    private final URL imageUrl = ImageFileSourceTest.class.getResource("/edu/wpi/grip/images/GRIP_Logo.png");
-    private final URL textUrl = ImageFileSourceTest.class.getResource("/edu/wpi/grip/images/NotAnImage.txt");
+    private File imageFile;
+    private File textFile;
     private static EventBus eventBus;
 
     @Before
-    public void setUp() {
+    public void setUp() throws URISyntaxException {
         this.eventBus = new EventBus();
+        textFile = new File(ImageFileSourceTest.class.getResource("/edu/wpi/grip/images/NotAnImage.txt").toURI());
+        imageFile = new File(ImageFileSourceTest.class.getResource("/edu/wpi/grip/images/GRIP_Logo.png").toURI());
     }
 
     @Test
     public void testLoadImageToMat() {
         // Given above setup
         // When
-        final ImageFileSource fileSource = new ImageFileSource(eventBus, this.imageUrl);
+        final ImageFileSource fileSource = new ImageFileSource(eventBus, this.imageFile);
         OutputSocket<Mat> outputSocket = fileSource.getOutputSockets()[0];
 
         // Then
@@ -41,14 +44,14 @@ public class ImageFileSourceTest {
 
     @Test
     public void testReadInTextFile() {
-        final ImageFileSource fileSource = new ImageFileSource(eventBus, this.textUrl);
+        final ImageFileSource fileSource = new ImageFileSource(eventBus, this.textFile);
         OutputSocket<Mat> outputSocket = fileSource.getOutputSockets()[0];
         assertTrue("No matrix should have been returned.", outputSocket.getValue().empty());
     }
 
     @Test
-    public void testReadInFileWithoutExtention() throws MalformedURLException {
-        final ImageFileSource fileSource = new ImageFileSource(eventBus, new URL("file://temp/fdkajdl3eaf"));
+    public void testReadInFileWithoutExtension() throws MalformedURLException {
+        final ImageFileSource fileSource = new ImageFileSource(eventBus, new File("file://temp/fdkajdl3eaf"));
         OutputSocket<Mat> outputSocket = fileSource.getOutputSockets()[0];
         assertTrue("No matrix should have been returned.", outputSocket.getValue().empty());
     }


### PR DESCRIPTION
Instead of using a java URL object, ImageFileSource should just take a
File and convert it to the right path format using the Paths class.

I tested this on a Windows machine, and it works.