### PR TITLE
Decrease the spacing between sockets

### DIFF
--- a/src/main/resources/edu/wpi/grip/ui/GRIP.css
+++ b/src/main/resources/edu/wpi/grip/ui/GRIP.css
@@ -133,7 +133,7 @@ Button.delete {
 }
 
 .step VBox, .source VBox {
-    -fx-spacing: 2em;
+    -fx-spacing: 0.5em;
 }
 
 .step .title {


### PR DESCRIPTION
The "tallest" step we currently have (sobel) now fits within the bottom
half of my screen without scrolling.