### PR TITLE
Update image previews in the UI thread

### DIFF
--- a/src/main/java/edu/wpi/grip/ui/preview/ImageSocketPreviewView.java
+++ b/src/main/java/edu/wpi/grip/ui/preview/ImageSocketPreviewView.java
@@ -5,6 +5,7 @@ import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.UnsignedBytes;
 import edu.wpi.grip.core.OutputSocket;
 import edu.wpi.grip.core.events.SocketChangedEvent;
+import javafx.application.Platform;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.PixelFormat;
@@ -56,62 +57,69 @@ public class ImageSocketPreviewView extends SocketPreviewView<Mat> {
      * (Mat -> Frame -> BufferedImage -> JavaFX Image) and is way too slow to use for a real-time video.
      */
     private void convertImage() {
-        final Mat mat = this.getSocket().getValue();
-        final int width = mat.cols();
-        final int height = mat.rows();
-        final int channels = mat.channels();
+        synchronized (this) {
+            final Mat mat = this.getSocket().getValue();
+            final int width = mat.cols();
+            final int height = mat.rows();
+            final int channels = mat.channels();
 
-        assert channels == 3 || channels == 1 :
-                "Only 3-channel BGR images or single-channel grayscale images can be previewed";
+            assert channels == 3 || channels == 1 :
+                    "Only 3-channel BGR images or single-channel grayscale images can be previewed";
 
-        assert mat.type() == CV_8U || mat.type() == CV_8S :
-                "Only images with 8 bits per channel can be previewed";
+            assert mat.type() == CV_8U || mat.type() == CV_8S :
+                    "Only images with 8 bits per channel can be previewed";
 
-        // Don't try to render empty images.
-        if (mat.empty()) {
-            this.imageView.setImage(null);
-            return;
-        }
+            // Don't try to render empty images.
+            if (mat.empty()) {
+                this.imageView.setImage(null);
+                return;
+            }
 
-        // If the size of the Mat changed for whatever reason, allocate a new image with the proper dimensions and a buffer
-        // big enough to hold all of the pixels in the image.
-        if (this.image == null || this.image.getWidth() != width || this.image.getHeight() != height) {
-            this.image = new WritableImage(width, height);
-            this.pixels = IntBuffer.allocate(width * height);
-        }
+            // If the size of the Mat changed for whatever reason, allocate a new image with the proper dimensions and a buffer
+            // big enough to hold all of the pixels in the image.
+            if (this.image == null || this.image.getWidth() != width || this.image.getHeight() != height) {
+                this.image = new WritableImage(width, height);
+                this.pixels = IntBuffer.allocate(width * height);
+            }
 
-        final ByteBuffer buffer = mat.<ByteBuffer>createBuffer();
-        final int stride = buffer.capacity() / height;
+            final ByteBuffer buffer = mat.<ByteBuffer>createBuffer();
+            final int stride = buffer.capacity() / height;
 
-        // Convert the data from the Mat into ARGB data that we can put into a JavaFX WritableImage
-        switch (channels) {
-            case 1:
-                // 1 channel - convert grayscale to ARGB
-                for (int y = 0; y < height; y++) {
-                    for (int x = 0; x < width; x++) {
-                        final int value = UnsignedBytes.toInt(buffer.get(stride * y + channels * x));
-                        this.pixels.put(width * y + x, (0xff << 24) | (value << 16) | (value << 8) | value);
+            // Convert the data from the Mat into ARGB data that we can put into a JavaFX WritableImage
+            switch (channels) {
+                case 1:
+                    // 1 channel - convert grayscale to ARGB
+                    for (int y = 0; y < height; y++) {
+                        for (int x = 0; x < width; x++) {
+                            final int value = UnsignedBytes.toInt(buffer.get(stride * y + channels * x));
+                            this.pixels.put(width * y + x, (0xff << 24) | (value << 16) | (value << 8) | value);
+                        }
                     }
-                }
 
-                break;
+                    break;
 
-            case 3:
-                // 3 channels - convert BGR to RGBA
-                for (int y = 0; y < height; y++) {
-                    for (int x = 0; x < width; x++) {
-                        final int b = UnsignedBytes.toInt(buffer.get(stride * y + channels * x));
-                        final int g = UnsignedBytes.toInt(buffer.get(stride * y + channels * x + 1));
-                        final int r = UnsignedBytes.toInt(buffer.get(stride * y + channels * x + 2));
-                        this.pixels.put(width * y + x, (0xff << 24) | (r << 16) | (g << 8) | b);
+                case 3:
+                    // 3 channels - convert BGR to RGBA
+                    for (int y = 0; y < height; y++) {
+                        for (int x = 0; x < width; x++) {
+                            final int b = UnsignedBytes.toInt(buffer.get(stride * y + channels * x));
+                            final int g = UnsignedBytes.toInt(buffer.get(stride * y + channels * x + 1));
+                            final int r = UnsignedBytes.toInt(buffer.get(stride * y + channels * x + 2));
+                            this.pixels.put(width * y + x, (0xff << 24) | (r << 16) | (g << 8) | b);
+                        }
                     }
+
+                    break;
+            }
+
+            final PixelFormat<IntBuffer> argb = PixelFormat.getIntArgbInstance();
+
+            Platform.runLater(() -> {
+                synchronized (this) {
+                    this.image.getPixelWriter().setPixels(0, 0, width, height, argb, this.pixels, width);
+                    this.imageView.setImage(this.image);
                 }
-
-                break;
+            });
         }
-
-        final PixelFormat<IntBuffer> argb = PixelFormat.getIntArgbInstance();
-        this.image.getPixelWriter().setPixels(0, 0, width, height, argb, this.pixels, width);
-        this.imageView.setImage(this.image);
     }
 }


### PR DESCRIPTION
This is probably the cause of the mysterious scenegraph
NullPointerException that came up before.  The scenegraph should only be
manipulated from the UI thread, and the preview code is actually running
in the thread that eventBus.post was called in, which is the webcam
executor thread.  When multiple threads are touchin the scenegraph
probably hundreds of times per second, a race condition occasionally
happens.

We'll probably need some stress testing to make sure it's actually
fixed.