### PR TITLE
Fixes the DefinedParamState passed to constructor not taking priority

### DIFF
--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/FileParser.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/FileParser.java
@@ -137,7 +137,7 @@ public class FileParser {
                 ),
                 new DefinedMethod("Laplacian", "Mat", "Mat"),
                 new DefinedMethod("dilate", false, "Mat", "Mat"),
-                new DefinedMethod("Canny", false, new DefinedParamType("Mat"), new DefinedParamType("Mat", DefinedParamType.DefinedParamState.OUTPUT)),
+                new DefinedMethod("Canny", false, new DefinedParamType("Mat"), new DefinedParamType("Mat", DefinedParamType.DefinedParamDirection.OUTPUT)),
                 new DefinedMethod("cornerMinEigenVal", false, "Mat", "Mat"),
                 new DefinedMethod("cornerHarris", false, "Mat", "Mat"),
                 new DefinedMethod("cornerEigenValsAndVecs", false, "Mat", "Mat"),
@@ -195,13 +195,13 @@ public class FileParser {
                         "enlarge an image, it will generally look best with CV_INTER_CUBIC (slow) or CV_INTER_LINEAR " +
                         "(faster but still looks OK)"),
                 new DefinedMethod("HoughLines", false,
-                        new DefinedParamType("Mat", DefinedParamType.DefinedParamState.INPUT_AND_OUTPUT),
-                        new DefinedParamType("Mat", DefinedParamType.DefinedParamState.OUTPUT)
+                        new DefinedParamType("Mat", DefinedParamType.DefinedParamDirection.INPUT_AND_OUTPUT),
+                        new DefinedParamType("Mat", DefinedParamType.DefinedParamDirection.OUTPUT)
                 ),
                 new DefinedMethod("rectangle", false,
-                        new DefinedParamType("Mat", DefinedParamType.DefinedParamState.INPUT_AND_OUTPUT),
+                        new DefinedParamType("Mat", DefinedParamType.DefinedParamDirection.INPUT_AND_OUTPUT),
                         new DefinedParamType("Point"))
-        ).setOutputDefaults("dst").setIgnoreDefaults("dtype");
+        ).setDirectionDefaults(DefinedParamType.DefinedParamDirection.OUTPUT, "dst").setIgnoreDefaults("dtype");
         new OpenCVMethodVisitor(collection).visit(imgprocDeclaration, compilationUnits);
         collection.generateCompilationUnits(collector, compilationUnits, operations);
         return compilationUnits;
@@ -249,7 +249,7 @@ public class FileParser {
 //                        new DefinedParamType("double")
 //                                .setDefaultValue(new PrimitiveDefaultValue(new PrimitiveType(PrimitiveType.Primitive.Double), "1"))
 //                )
-        ).setOutputDefaults("dst").setIgnoreDefaults("dtype");
+        ).setDirectionDefaults(DefinedParamType.DefinedParamDirection.OUTPUT, "dst").setIgnoreDefaults("dtype");
         new OpenCVMethodVisitor(collection).visit(coreDeclaration, compilationUnits);
 
         collection.generateCompilationUnits(collector, compilationUnits, operations);

--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedMethod.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedMethod.java
@@ -184,7 +184,7 @@ public final class DefinedMethod {
                     definedParamType.setDefaultValue(collector.getDefaultValueFor(defaultValue));
                 }
                 if (collectionOf.isOutputDefault(param.getId().getName())) {
-                    definedParamType.setOutput();
+                    definedParamType.trySetOutput();
                 }
                 if (collectionOf.shouldIgnore(param.getId().getName())){
                     definedParamType.setIgnored();

--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedMethod.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedMethod.java
@@ -183,9 +183,14 @@ public final class DefinedMethod {
                 if (defaultValue != null && collector.hasDefaultValueFor(defaultValue)) {
                     definedParamType.setDefaultValue(collector.getDefaultValueFor(defaultValue));
                 }
-                if (collectionOf.isOutputDefault(param.getId().getName())) {
-                    definedParamType.trySetOutput();
-                }
+
+                /*
+                 * Sets the defined params direction given the mapping provided to the collector in the File Parser.
+                 */
+                collectionOf
+                        .getDefaultDirection(param.getId().getName())
+                        .ifPresent(definedParamDirection -> definedParamType.trySetDirection(definedParamDirection));
+
                 if (collectionOf.shouldIgnore(param.getId().getName())){
                     definedParamType.setIgnored();
                 }

--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedMethodCollection.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedMethodCollection.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 public class DefinedMethodCollection {
     private final String className;
     private final Map<String, DefinedMethod> definedMethodMap;
-    private final Set<String> outputDefaults = new HashSet<>();
+    private final Map<DefinedParamType.DefinedParamDirection, Set<String>> directionDefault = new HashMap<>();
     private final Set<String> ignoreDefaults = new HashSet<>();
 
     public DefinedMethodCollection(String className, DefinedMethod... methodList) {
@@ -28,8 +28,9 @@ public class DefinedMethodCollection {
         this.definedMethodMap = methodList.stream().collect(Collectors.toMap(DefinedMethod::getMethodName, t -> t));
     }
 
-    public DefinedMethodCollection setOutputDefaults(String... paramNames) {
-        outputDefaults.addAll(Arrays.asList(paramNames));
+    public DefinedMethodCollection setDirectionDefaults(DefinedParamType.DefinedParamDirection direction, String... paramNames) {
+        directionDefault.putIfAbsent(direction, new HashSet<>());
+        directionDefault.get(direction).addAll(Arrays.asList(paramNames));
         return this;
     }
 
@@ -50,8 +51,18 @@ public class DefinedMethodCollection {
         return className;
     }
 
-    public boolean isOutputDefault(String check) {
-        return outputDefaults.contains(check);
+    /**
+     * Gets the default direction for a given param's Variable Identifier
+     * @param check The Variable identifier to check
+     * @return The direction this has been mapped to
+     */
+    public Optional<DefinedParamType.DefinedParamDirection> getDefaultDirection(String check) {
+        for(DefinedParamType.DefinedParamDirection direction : DefinedParamType.DefinedParamDirection.values()){
+            if(directionDefault.getOrDefault(direction, Collections.EMPTY_SET).contains(check)){
+                return Optional.of(direction);
+            }
+        }
+        return Optional.empty();
     }
 
     public boolean shouldIgnore(String check) {

--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedParamType.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedParamType.java
@@ -25,7 +25,7 @@ import static com.github.javaparser.ASTHelper.createReferenceType;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DefinedParamType {
-    public enum DefinedParamState {
+    public enum DefinedParamDirection {
         INPUT,
         OUTPUT,
         INPUT_AND_OUTPUT;
@@ -41,7 +41,7 @@ public class DefinedParamType {
     }
 
     private final String type;
-    private Optional<DefinedParamState> state;
+    private Optional<DefinedParamDirection> direction;
     private Optional<Parameter> parameter = Optional.empty();
     private Optional<DefaultValue> defaultValue = Optional.empty();
     private Optional<String> literalDefaultValue = Optional.empty();
@@ -58,7 +58,7 @@ public class DefinedParamType {
      */
     public DefinedParamType(String type) {
         this.type = type;
-        this.state = Optional.empty();
+        this.direction = Optional.empty();
     }
 
     /**
@@ -74,11 +74,11 @@ public class DefinedParamType {
     /**
      *
      * @param type The type of param that this should match
-     * @param state The state of the param. Will override whatever defaults are set by the method collector
+     * @param direction The direction of the param. Will override whatever defaults are set by the method collector
      */
-    public DefinedParamType(String type, DefinedParamState state) {
+    public DefinedParamType(String type, DefinedParamDirection direction) {
         this(type);
-        this.state = Optional.ofNullable(state);
+        this.direction = Optional.ofNullable(direction);
     }
 
     public static List<DefinedParamType> fromStrings(List<String> params) {
@@ -184,11 +184,11 @@ public class DefinedParamType {
     }
 
     public boolean isInput() {
-        return getState().isInput();
+        return getDirection().isInput();
     }
 
     public boolean isOutput() {
-        return getState().isOutput();
+        return getDirection().isOutput();
     }
 
     public boolean isIgnored() {
@@ -196,13 +196,13 @@ public class DefinedParamType {
     }
 
     /**
-     * Gets the state of this param it hasn't been assigned prior to calling this method then it is assigned by this call.
-     * @return The state of this param.
+     * Gets the direction of this param it hasn't been assigned prior to calling this method then it is assigned by this call.
+     * @return The direction of this param.
      */
-    public DefinedParamState getState() {
-        if (state.isPresent()) return state.get();
-        state = Optional.of(DefinedParamState.INPUT);
-        return state.get();
+    public DefinedParamDirection getDirection() {
+        if (direction.isPresent()) return direction.get();
+        direction = Optional.of(DefinedParamDirection.INPUT);
+        return direction.get();
     }
 
     public String getName() {
@@ -231,8 +231,8 @@ public class DefinedParamType {
     /**
      * Makes this param an output if it hasn't been explicitly set in the constructor
      */
-    void trySetOutput() {
-        state = Optional.of(state.orElseGet(() ->DefinedParamState.OUTPUT));
+    void trySetDirection(DefinedParamDirection direction) {
+        this.direction = Optional.of(this.direction.orElseGet(() -> direction));
     }
 
     public void setIgnored() {

--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedParamType.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/settings/DefinedParamType.java
@@ -41,7 +41,7 @@ public class DefinedParamType {
     }
 
     private final String type;
-    private DefinedParamState state;
+    private Optional<DefinedParamState> state;
     private Optional<Parameter> parameter = Optional.empty();
     private Optional<DefaultValue> defaultValue = Optional.empty();
     private Optional<String> literalDefaultValue = Optional.empty();
@@ -54,20 +54,31 @@ public class DefinedParamType {
      * Defines a Param type that a method must match.
      * Defaults the value to being an input.
      *
-     * @param type
+     * @param type the type of param that this should match
      */
     public DefinedParamType(String type) {
-        this(type, DefinedParamState.INPUT);
+        this.type = type;
+        this.state = Optional.empty();
     }
 
+    /**
+     * Used for testing only.
+     * @param type
+     * @param param
+     */
     public DefinedParamType(String type, Parameter param) {
         this(type);
         parameter = Optional.of(param);
     }
 
+    /**
+     *
+     * @param type The type of param that this should match
+     * @param state The state of the param. Will override whatever defaults are set by the method collector
+     */
     public DefinedParamType(String type, DefinedParamState state) {
-        this.type = type;
-        this.state = state;
+        this(type);
+        this.state = Optional.ofNullable(state);
     }
 
     public static List<DefinedParamType> fromStrings(List<String> params) {
@@ -173,11 +184,11 @@ public class DefinedParamType {
     }
 
     public boolean isInput() {
-        return state.isInput();
+        return getState().isInput();
     }
 
     public boolean isOutput() {
-        return state.isOutput();
+        return getState().isOutput();
     }
 
     public boolean isIgnored() {
@@ -185,10 +196,13 @@ public class DefinedParamType {
     }
 
     /**
-     * @return The state of this param
+     * Gets the state of this param it hasn't been assigned prior to calling this method then it is assigned by this call.
+     * @return The state of this param.
      */
     public DefinedParamState getState() {
-        return state;
+        if (state.isPresent()) return state.get();
+        state = Optional.of(DefinedParamState.INPUT);
+        return state.get();
     }
 
     public String getName() {
@@ -215,10 +229,10 @@ public class DefinedParamType {
     }
 
     /**
-     * Makes this param an output.
+     * Makes this param an output if it hasn't been explicitly set in the constructor
      */
-    void setOutput() {
-        state = DefinedParamState.OUTPUT;
+    void trySetOutput() {
+        state = Optional.of(state.orElseGet(() ->DefinedParamState.OUTPUT));
     }
 
     public void setIgnored() {

--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/templates/SocketHintDeclaration.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/templates/SocketHintDeclaration.java
@@ -67,7 +67,7 @@ public class SocketHintDeclaration {
     }
 
 
-    public SocketHintDeclaration(DefaultValueCollector collector, Type genericType, List<DefinedParamType> paramTypes, DefinedParamType.DefinedParamState state) {
+    public SocketHintDeclaration(DefaultValueCollector collector, Type genericType, List<DefinedParamType> paramTypes, DefinedParamType.DefinedParamDirection state) {
         /* Convert this to the 'boxed' type if this is a PrimitiveType */
         this.genericType =
                 genericType instanceof PrimitiveType ?

--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/templates/SocketHintDeclarationCollection.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/templates/SocketHintDeclarationCollection.java
@@ -50,10 +50,10 @@ public class SocketHintDeclarationCollection {
 
         // Figure out which hint map to put this defined param type into
         for (DefinedParamType type : paramTypes) {
-            if (type.getState().isInput()) {
+            if (type.getDirection().isInput()) {
                 addToInput(type);
             }
-            if (type.getState().isOutput()) {
+            if (type.getDirection().isOutput()) {
                 addToOutput(type);
             }
         }
@@ -241,10 +241,10 @@ public class SocketHintDeclarationCollection {
     public List<SocketHintDeclaration> getAllSocketHints() {
         List<SocketHintDeclaration> socketHintDeclarations = new ArrayList<>();
         for (Type type : inputHintsMap.keySet()) {
-            socketHintDeclarations.add(new SocketHintDeclaration(collector, type, inputHintsMap.get(type), DefinedParamType.DefinedParamState.INPUT));
+            socketHintDeclarations.add(new SocketHintDeclaration(collector, type, inputHintsMap.get(type), DefinedParamType.DefinedParamDirection.INPUT));
         }
         for (Type type : outputHintsMap.keySet()) {
-            socketHintDeclarations.add(new SocketHintDeclaration(collector, type, outputHintsMap.get(type), DefinedParamType.DefinedParamState.OUTPUT));
+            socketHintDeclarations.add(new SocketHintDeclaration(collector, type, outputHintsMap.get(type), DefinedParamType.DefinedParamDirection.OUTPUT));
         }
         return socketHintDeclarations;
     }


### PR DESCRIPTION
Before the `setOutput` would force the state of the param. Now it only
sets it if it hasn't been set by the constructor.

Related #71