### PR TITLE
Fix cross-platform DPI scaling issues

### DIFF
--- a/src/main/java/edu/wpi/grip/Main.java
+++ b/src/main/java/edu/wpi/grip/Main.java
@@ -1,12 +1,12 @@
 package edu.wpi.grip;
 
 import edu.wpi.grip.ui.ExceptionAlert;
+import edu.wpi.grip.ui.util.DPIUtility;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.stage.Screen;
 import javafx.stage.Stage;
 
 public class Main extends Application {
@@ -44,13 +44,7 @@ public class Main extends Application {
             });
         });
 
-        // Set the root font size based on the DPI of the primary screen.  As long as all sizes are defined in ems,
-        // this means the GUI will be a reasonable physical size on high DPI displays as it is on normal displays.
-        // TODO: Maybe make this part of a preference
-        if (Screen.getPrimary().getDpi() >= 192.0) {
-            root.setStyle("-fx-font-size: 20px");
-        }
-
+        root.setStyle("-fx-font-size: " + DPIUtility.FONT_SIZE + "px");
 
         stage.setTitle("GRIP Computer Vision Engine");
         stage.setScene(new Scene(root));

--- a/src/main/java/edu/wpi/grip/ui/OperationView.java
+++ b/src/main/java/edu/wpi/grip/ui/OperationView.java
@@ -4,6 +4,7 @@ import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.Operation;
 import edu.wpi.grip.core.Step;
 import edu.wpi.grip.core.events.StepAddedEvent;
+import edu.wpi.grip.ui.util.DPIUtility;
 import edu.wpi.grip.ui.util.StyleClassNameUtility;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -13,7 +14,6 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.GridPane;
-import javafx.stage.Screen;
 
 import java.io.IOException;
 import java.net.URL;
@@ -38,8 +38,6 @@ public class OperationView extends GridPane implements Initializable {
     @FXML
     private ImageView icon;
 
-    private static final double ICON_SIZE_INCHES = 0.5;
-
     public OperationView(EventBus eventBus, Operation operation) {
         checkNotNull(eventBus);
         checkNotNull(operation);
@@ -60,12 +58,10 @@ public class OperationView extends GridPane implements Initializable {
 
     @Override
     public void initialize(URL url, ResourceBundle resourceBundle) {
-        final double iconSizePixels = ICON_SIZE_INCHES * Screen.getPrimary().getDpi();
-
         this.setId(StyleClassNameUtility.idNameFor(this.operation));
         this.name.setText(this.operation.getName());
         this.description.setText(this.operation.getDescription());
-        this.description.setMaxHeight(iconSizePixels);
+        this.description.setMaxHeight(DPIUtility.LARGE_ICON_SIZE);
 
         final Tooltip tooltip = new Tooltip(this.operation.getDescription());
         tooltip.setPrefWidth(400.0);
@@ -79,8 +75,8 @@ public class OperationView extends GridPane implements Initializable {
         // Make the icon a fixed width and height in inches.  It would be cleaner to define this in CSS, but JavaFX
         // doesn't allow fitWidth or fitHeight to be used from CSS, and defining it in FXML would not allow it to be
         // set dynamically based on DPI.
-        this.icon.setFitWidth(iconSizePixels);
-        this.icon.setFitHeight(iconSizePixels);
+        this.icon.setFitWidth(DPIUtility.LARGE_ICON_SIZE);
+        this.icon.setFitHeight(DPIUtility.LARGE_ICON_SIZE);
 
 
         // When the user clicks the operation, add a new step.

--- a/src/main/java/edu/wpi/grip/ui/pipeline/AddSourceView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/AddSourceView.java
@@ -4,6 +4,7 @@ import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.events.SourceAddedEvent;
 import edu.wpi.grip.core.sources.ImageFileSource;
 import edu.wpi.grip.core.sources.WebcamSource;
+import edu.wpi.grip.ui.util.DPIUtility;
 import javafx.event.EventHandler;
 import javafx.scene.Parent;
 import javafx.scene.control.*;
@@ -29,8 +30,6 @@ import java.util.function.Predicate;
  * in a file picker that the user can use to browse for an image.
  */
 public class AddSourceView extends HBox {
-
-    private final static double ICON_SIZE_INCHES = 1.0 / 6.0;
 
     private final EventBus eventBus;
 
@@ -92,13 +91,12 @@ public class AddSourceView extends HBox {
     }
 
     /**
-     * Add a new button for adding a source.  This method takes care of resizing the button graphic and setting the
-     * event handler.
+     * Add a new button for adding a source.  This method takes care of setting the event handler.
      */
     private void addButton(String text, URL graphicURL, EventHandler<? super MouseEvent> onMouseClicked) {
         final ImageView graphic = new ImageView(graphicURL.toString());
-        graphic.setFitWidth(Screen.getPrimary().getDpi() * ICON_SIZE_INCHES);
-        graphic.setFitHeight(Screen.getPrimary().getDpi() * ICON_SIZE_INCHES);
+        graphic.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
+        graphic.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
 
         final Button button = new Button(text, graphic);
         button.setTextAlignment(TextAlignment.CENTER);

--- a/src/main/java/edu/wpi/grip/ui/pipeline/ConnectionView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/ConnectionView.java
@@ -2,6 +2,7 @@ package edu.wpi.grip.ui.pipeline;
 
 import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.Connection;
+import edu.wpi.grip.ui.util.DPIUtility;
 import edu.wpi.grip.ui.util.StyleClassNameUtility;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -33,7 +34,7 @@ public class ConnectionView extends CubicCurve {
 
         this.setFill(FILL);
         this.setStroke(STROKE);
-        this.setStrokeWidth(2.0);
+        this.setStrokeWidth(DPIUtility.STROKE_WIDTH);
 
         this.getStyleClass().add(StyleClassNameUtility.classNameFor(connection));
 

--- a/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketView.java
@@ -4,6 +4,7 @@ import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.OutputSocket;
 import edu.wpi.grip.core.Socket;
 import edu.wpi.grip.core.SocketHint;
+import edu.wpi.grip.ui.util.DPIUtility;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
@@ -12,7 +13,6 @@ import javafx.scene.control.ToggleButton;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
-import javafx.stage.Screen;
 
 import java.io.IOException;
 import java.net.URL;
@@ -26,8 +26,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * the output.
  */
 public class OutputSocketView extends HBox implements Initializable {
-
-    private static final double BUTTON_ICON_SIZE_INCHES = 1.0 / 6.0;
 
     @FXML
     private Label identifier;
@@ -88,11 +86,10 @@ public class OutputSocketView extends HBox implements Initializable {
         // Set all button icons to be the same size, regardless of screen resolution
         final ImageView previewIcon = (ImageView) this.preview.getGraphic();
         final ImageView publishIcon = (ImageView) this.publish.getGraphic();
-        final double buttonSize = BUTTON_ICON_SIZE_INCHES * Screen.getPrimary().getDpi();
-        previewIcon.setFitWidth(buttonSize);
-        previewIcon.setFitHeight(buttonSize);
-        publishIcon.setFitWidth(buttonSize);
-        publishIcon.setFitHeight(buttonSize);
+        previewIcon.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
+        previewIcon.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
+        publishIcon.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
+        publishIcon.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
 
         this.eventBus.register(this);
     }

--- a/src/main/java/edu/wpi/grip/ui/pipeline/StepView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/StepView.java
@@ -8,6 +8,7 @@ import edu.wpi.grip.core.events.StepMovedEvent;
 import edu.wpi.grip.core.events.StepRemovedEvent;
 import edu.wpi.grip.ui.pipeline.input.InputSocketView;
 import edu.wpi.grip.ui.pipeline.input.InputSocketViewFactory;
+import edu.wpi.grip.ui.util.DPIUtility;
 import edu.wpi.grip.ui.util.StyleClassNameUtility;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -17,7 +18,6 @@ import javafx.scene.control.Labeled;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.VBox;
-import javafx.stage.Screen;
 
 import java.io.IOException;
 import java.net.URL;
@@ -67,11 +67,9 @@ public class StepView extends VBox implements Initializable {
         this.getStyleClass().add(StyleClassNameUtility.classNameFor(this.step));
         this.title.setText(this.step.getOperation().getName());
 
-        this.step.getOperation().getIcon().ifPresent(icon -> {
-            this.icon.setImage(new Image(icon));
-            this.icon.setFitWidth(Screen.getPrimary().getDpi() * 0.25);
-            this.icon.setFitHeight(Screen.getPrimary().getDpi() * 0.25);
-        });
+        this.step.getOperation().getIcon().ifPresent(icon -> this.icon.setImage(new Image(icon)));
+        this.icon.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
+        this.icon.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
 
         // Add a SocketControlView for each input socket and output socket
         for (InputSocket<?> inputSocket : this.step.getInputSockets()) {

--- a/src/main/java/edu/wpi/grip/ui/preview/BlobsSocketPreviewView.java
+++ b/src/main/java/edu/wpi/grip/ui/preview/BlobsSocketPreviewView.java
@@ -13,7 +13,6 @@ import javafx.scene.control.Separator;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.VBox;
-import javafx.stage.Screen;
 
 import static org.bytedeco.javacpp.opencv_core.*;
 import static org.bytedeco.javacpp.opencv_imgproc.*;
@@ -37,7 +36,7 @@ public class BlobsSocketPreviewView extends SocketPreviewView<BlobsReport> {
         super(eventBus, socket);
 
         final VBox content = new VBox();
-        content.setSpacing(Screen.getPrimary().getDpi() * 0.1);
+        content.getStyleClass().add("preview-box");
         content.getChildren().add(this.imageView);
         content.getChildren().add(new Separator(Orientation.HORIZONTAL));
         content.getChildren().add(this.infoLabel);

--- a/src/main/java/edu/wpi/grip/ui/preview/LinesSocketPreviewView.java
+++ b/src/main/java/edu/wpi/grip/ui/preview/LinesSocketPreviewView.java
@@ -40,7 +40,7 @@ public class LinesSocketPreviewView extends SocketPreviewView<LinesReport> {
         super(eventBus, socket);
 
         final VBox content = new VBox();
-        content.setSpacing(Screen.getPrimary().getDpi() * 0.1);
+        content.getStyleClass().add("preview-box");
         content.getChildren().add(this.imageView);
         content.getChildren().add(new Separator(Orientation.HORIZONTAL));
         content.getChildren().add(this.infoLabel);

--- a/src/main/java/edu/wpi/grip/ui/util/DPIUtility.java
+++ b/src/main/java/edu/wpi/grip/ui/util/DPIUtility.java
@@ -1,0 +1,24 @@
+package edu.wpi.grip.ui.util;
+
+import com.google.common.base.StandardSystemProperty;
+import javafx.stage.Screen;
+
+/**
+ * Utilities for determining pixel sizes in a way that should work well across operating systems and screen resolutions
+ */
+public class DPIUtility {
+
+    private final static double HIDPI_SCALE = 2.0;
+
+    public final static double FONT_SIZE = 11.0 * (isManualHiDPI() ? HIDPI_SCALE : 1.0);
+    public final static double SMALL_ICON_SIZE = 16.0 * (isManualHiDPI() ? HIDPI_SCALE : 1.0);
+    public final static double LARGE_ICON_SIZE = 48.0 * (isManualHiDPI() ? HIDPI_SCALE : 1.0);
+    public final static double STROKE_WIDTH = 2.0 * (isManualHiDPI() ? HIDPI_SCALE : 1.0);
+
+    private static boolean isManualHiDPI() {
+        // We need to do manual size adjustments for HiDPI on Linux.  JavaFX automatically does this on Windows.
+        // TODO: test on OS X on a Retina display
+        final String osName = StandardSystemProperty.OS_NAME.value();
+        return Screen.getPrimary().getDpi() >= 192.0 && "Linux".equals(osName);
+    }
+}

--- a/src/main/resources/edu/wpi/grip/ui/GRIP.css
+++ b/src/main/resources/edu/wpi/grip/ui/GRIP.css
@@ -177,3 +177,11 @@ VBox.sockets {
     -fx-background-insets: -0.2, 1, 2, -1.4, 2.6;
     -fx-background-radius: 1em;
 }
+
+.small-icon-button {
+    -fx-padding: 0.5em;
+}
+
+.preview-box {
+    -fx-spacing: 0.5em;
+}

--- a/src/main/resources/edu/wpi/grip/ui/pipeline/OutputSocket.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/pipeline/OutputSocket.fxml
@@ -9,20 +9,20 @@
 <fx:root styleClass="socket" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/null"
          xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER_RIGHT">
     <children>
-        <ToggleButton fx:id="preview">
+        <ToggleButton fx:id="preview" styleClass="small-icon-button">
             <graphic>
                 <ImageView>
-                    <Image url="@../icons/preview.png" requestedWidth="32" requestedHeight="32"/>
+                    <Image url="@../icons/preview.png"/>
                 </ImageView>
             </graphic>
             <tooltip>
                 <Tooltip text="Preview Socket"/>
             </tooltip>
         </ToggleButton>
-        <ToggleButton fx:id="publish">
+        <ToggleButton fx:id="publish" styleClass="small-icon-button">
             <graphic>
                 <ImageView>
-                    <Image url="@../icons/publish.png" requestedWidth="32" requestedHeight="32"/>
+                    <Image url="@../icons/publish.png"/>
                 </ImageView>
             </graphic>
             <tooltip>


### PR DESCRIPTION
This change adds a "DPIUtility" class and migrates all dpi-specific
sizing to use it.  This should make the sizing a little more consistant
accross platforms and screen resolutions without including a bunch of
hacky hard-coded scales everywhere we use an image.