### PR TITLE
Small GUI enhancements

### DIFF
--- a/src/main/java/edu/wpi/grip/ui/MainWindowView.java
+++ b/src/main/java/edu/wpi/grip/ui/MainWindowView.java
@@ -43,8 +43,13 @@ public class MainWindowView extends VBox {
             throw new RuntimeException("FXML Failed to load", e);
         }
 
-        this.topPane.getItems().addAll(new PreviewsView(eventBus), new PaletteView(eventBus));
-        this.bottomPane.setContent(new PipelineView(eventBus, new Pipeline(eventBus)));
+        final PreviewsView previewsView = new PreviewsView(eventBus);
+        final PaletteView paletteView = new PaletteView(eventBus);
+        final PipelineView pipelineView = new PipelineView(eventBus, new Pipeline(eventBus));
+
+        this.topPane.getItems().addAll(previewsView, paletteView);
+        this.bottomPane.setContent(pipelineView);
+        pipelineView.prefHeightProperty().bind(this.bottomPane.heightProperty());
 
         // Add the default built-in operations to the palette
         eventBus.post(new OperationAddedEvent(new BlurOperation()));

--- a/src/main/java/edu/wpi/grip/ui/PaletteView.java
+++ b/src/main/java/edu/wpi/grip/ui/PaletteView.java
@@ -65,6 +65,9 @@ public class PaletteView extends VBox {
         this.operations.getChildren().addListener(filterOperations);
         this.operationSearch.textProperty().addListener(filterOperations);
 
+        // The palette should have a lower priority for resizing than other elements
+        this.getProperties().put("resizable-with-parent", false);
+
         this.eventBus.register(this);
     }
 

--- a/src/main/java/edu/wpi/grip/ui/pipeline/ConnectionView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/ConnectionView.java
@@ -7,7 +7,6 @@ import edu.wpi.grip.ui.util.StyleClassNameUtility;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.geometry.Point2D;
-import javafx.scene.paint.Paint;
 import javafx.scene.shape.CubicCurve;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -17,9 +16,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * connected to which inputs between different steps in the pipeline.a
  */
 public class ConnectionView extends CubicCurve {
-
-    private static final Paint FILL = null;
-    private static final Paint STROKE = Paint.valueOf("#575757");
 
     private final EventBus eventBus;
     private final Connection connection;
@@ -32,11 +28,8 @@ public class ConnectionView extends CubicCurve {
         this.eventBus = eventBus;
         this.connection = connection;
 
-        this.setFill(FILL);
-        this.setStroke(STROKE);
         this.setStrokeWidth(DPIUtility.STROKE_WIDTH);
-
-        this.getStyleClass().add(StyleClassNameUtility.classNameFor(connection));
+        this.getStyleClass().addAll("connection", StyleClassNameUtility.classNameFor(connection));
 
         this.controlX1Property().bind(this.startXProperty().add(this.endXProperty()).multiply(0.5));
         this.controlY1Property().bind(this.startYProperty());

--- a/src/main/resources/edu/wpi/grip/ui/GRIP.css
+++ b/src/main/resources/edu/wpi/grip/ui/GRIP.css
@@ -7,23 +7,12 @@
     -fx-pref-height: 70.0em;
 }
 
-.main-window Label.status {
-    -fx-text-fill: #999999;
-    -fx-padding: 0.5em 1.0em;
-}
-
-.main-window Label.placeholder {
-    -fx-text-fill: #555555;
+.pane-title {
+    -fx-background-color: -fx-control-inner-background;
     -fx-font-weight: bold;
-    -fx-padding: 1.0em 2.0em;
+    -fx-padding: 1.0em;
+    -fx-border-width: 1px;
 }
-
-Label.pane-title {
-    -fx-text-fill: #555555;
-    -fx-font-weight: bold;
-    -fx-padding: 1.0em 2.0em;
-}
-
 .palette {
     -fx-min-width: 20em;
 }
@@ -31,14 +20,9 @@ Label.pane-title {
 .operation {
     -fx-cursor: hand;
     -fx-hgap: 1em;
-    -fx-vgap: 0em;
-    -fx-padding: 1em;
-
-    -fx-background-color:
-        linear-gradient(to bottom, derive(-fx-color,-15%) 95%, derive(-fx-color,-25%) 100%),
-        -fx-inner-border,
-        -fx-body-color;
-    -fx-background-insets: 0, 1, 2;
+    -fx-padding: 0.5em;
+    -fx-alignment: center-left;
+    -fx-background-color: -fx-color;
 }
 
 .operation:hover {
@@ -58,10 +42,6 @@ Label.operation-description {
     -fx-alignment: top-left;
 }
 
-ImageView.operation-icon {
-    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.25), 32, 0, 4, 4);
-}
-
 .sink-window {
     -fx-pref-width: 60.0em;
     -fx-pref-height: 40.0em;
@@ -79,9 +59,23 @@ ImageView.operation-icon {
     -fx-pref-width: 40em;
 }
 
+.previews, .palette {
+    -fx-focus-color: transparent;
+    -fx-faint-focus-color: transparent;
+}
+
+.scroll-pane {
+    -fx-background-color: -fx-control-inner-background;
+
+}
+
+.palette {
+    -fx-pref-width: 30em;
+}
+
 .previews HBox {
     -fx-spacing: 1em;
-    -fx-padding: 1em;
+    -fx-padding: 0.5em;
 }
 
 .socket-preview .title {
@@ -90,12 +84,12 @@ ImageView.operation-icon {
 }
 
 .sources {
-    -fx-padding: 1em;
+    -fx-padding: 0.5em;
     -fx-spacing: 1em;
 }
 
 .source {
-    -fx-padding: 1em;
+    -fx-padding: 0.5em;
     -fx-spacing: 1em;
     -fx-border-width: 1px;
     -fx-border-color: -fx-box-border;
@@ -108,19 +102,19 @@ Label.source-name {
 }
 
 Button.add-source {
-    -fx-padding: 1em;
+    -fx-padding: 0.5em;
 }
 
 .steps {
     -fx-spacing: 1em;
-    -fx-padding: 1em;
+    -fx-padding: 0.5em;
 }
 
 .step {
     -fx-pref-width: 15em;
     -fx-border-color: -fx-box-border;
     -fx-background-color: -fx-background;
-    -fx-padding: 1em;
+    -fx-padding: 1.0em;
     -fx-spacing: 0.5em;
 }
 
@@ -154,6 +148,7 @@ VBox.sockets {
     -fx-min-height: 1em;
     -fx-max-width: 1em;
     -fx-max-height: 1em;
+    -fx-cursor: hand;
 }
 
 .socket-handle:connecting {
@@ -168,11 +163,11 @@ VBox.sockets {
 }
 
 .socket-handle:connected {
-    -fx-background-color: -fx-shadow-highlight-color, -fx-outer-border, -fx-inner-border, #575757;
+    -fx-background-color: -fx-shadow-highlight-color, -fx-outer-border, -fx-inner-border, -fx-mark-color;
 }
 
 .socket-handle:connected:focused {
-    -fx-background-color: -fx-focus-color, -fx-inner-border, -fx-body-color, -fx-faint-focus-color, -fx-text-base-color;
+    -fx-background-color: -fx-focus-color, -fx-inner-border, -fx-body-color, -fx-faint-focus-color, -fx-mark-color;
     -fx-background-insets: -0.2, 1, 2, -1.4, 2.6;
     -fx-background-radius: 1em;
 }
@@ -183,4 +178,9 @@ VBox.sockets {
 
 .preview-box {
     -fx-spacing: 0.5em;
+}
+
+.connection {
+    -fx-stroke: -fx-mark-color;
+    -fx-fill: none;
 }

--- a/src/main/resources/edu/wpi/grip/ui/Palette.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/Palette.fxml
@@ -7,8 +7,8 @@
 <fx:root fillWidth="true" styleClass="palette" type="javafx.scene.layout.VBox" xmlns="http://javafx.com/javafx/8.0.40"
          xmlns:fx="http://javafx.com/fxml/1">
     <children>
-        <Label styleClass="pane-title" text="Operation Palette"/>
-        <CustomTextField fx:id="operationSearch" promptText="Search"></CustomTextField>
+        <Label styleClass="pane-title" text="Operation Palette" maxWidth="Infinity"/>
+        <CustomTextField fx:id="operationSearch" promptText="Search"/>
         <ScrollPane fx:id="palettePane" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED">
             <VBox fx:id="operations"/>
         </ScrollPane>

--- a/src/main/resources/edu/wpi/grip/ui/pipeline/Pipeline.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/pipeline/Pipeline.fxml
@@ -9,13 +9,13 @@
     <children>
         <HBox>
             <VBox fillWidth="true">
-                <Label styleClass="pane-title" text="Sources"/>
+                <Label styleClass="pane-title" text="Sources" maxWidth="Infinity"/>
                 <Separator orientation="HORIZONTAL"/>
                 <Pane fx:id="addSourcePane"/>
                 <VBox fx:id="sources" styleClass="sources"/>
             </VBox>
             <Separator orientation="VERTICAL"/>
-            <HBox fx:id="steps" styleClass="steps"/>
+            <HBox fx:id="steps" styleClass="steps" fillHeight="false"/>
         </HBox>
         <Group fx:id="connections" mouseTransparent="true">
             <StackPane.alignment>TOP_LEFT</StackPane.alignment>

--- a/src/main/resources/edu/wpi/grip/ui/preview/Previews.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/preview/Previews.fxml
@@ -9,7 +9,7 @@
 <fx:root type="javafx.scene.layout.VBox" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1"
          fillWidth="true" maxHeight="Infinity" styleClass="previews">
     <children>
-        <Label styleClass="pane-title" text="Preview" VBox.Vgrow="NEVER"/>
+        <Label styleClass="pane-title" text="Preview" VBox.Vgrow="NEVER" maxWidth="Infinity"/>
         <ScrollPane hbarPolicy="AS_NEEDED" vbarPolicy="AS_NEEDED" fitToWidth="false" fitToHeight="false"
                     maxHeight="Infinity" VBox.Vgrow="ALWAYS">
             <HBox fx:id="previewBox"/>


### PR DESCRIPTION
This fixes some small issues with the GUI that have been bugging me:

- There's too much padding in a lot of places.
- The operations in the palette use a weird custom gradient and shadow
  effect.
- Steps resize themselves to all be the same height, regardless of their
  contents.
- The pipeline does not fill all the way to the bottom of the screen,
  leaving a blank space where the border between the sources
  and the steps disappears.
- The operation palette gets bigger when to make the window wider,
  taking up more of the preview pane's space.
- "Focus" glowing effects show up on the preview pane and
  palette if you click them.

**Before**:
![before](https://cloud.githubusercontent.com/assets/3964980/11152244/7195e8c2-89ff-11e5-9fcf-72bd6c8e03bd.png)

**After**:
![after](https://cloud.githubusercontent.com/assets/3964980/11152246/762059d6-89ff-11e5-8f57-5e46e39c2014.png)
