### PR TITLE
Improve operation searching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 dependencies {
     compile group: 'org.controlsfx', name: 'controlsfx', version: '8.40.10'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
-    compile group: 'com.google.inject', name: 'guice', version: '4.0'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'org.python', name: 'jython', version: '2.7.0'
     compile group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.8'
     compile group: 'org.bytedeco', name: 'javacv', version: '1.1'

--- a/src/main/java/edu/wpi/grip/ui/util/SearchUtility.java
+++ b/src/main/java/edu/wpi/grip/ui/util/SearchUtility.java
@@ -1,0 +1,39 @@
+package edu.wpi.grip.ui.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility for fuzzy text searching
+ */
+public class SearchUtility {
+
+    /**
+     * @return true if query if approximately a substring of text, not taking into account capitalization, whitespace,
+     * or minor typos
+     */
+    public static boolean fuzzyContains(String text, String query) {
+        if (query.isEmpty()) return true;
+        if (text.isEmpty()) return false;
+
+        // Normalize the capitalization and whitespace (which are currently both pretty inconsistent among operations)
+        text = text.toUpperCase().replaceAll("[^a-zA-Z]", "");
+        query = query.toUpperCase().replaceAll("[^a-zA-Z]", "");
+
+        if (query.length() <= text.length()) {
+            // Assuming the search string is smaller than the name of the operation, show it if the search string is very
+            // close to a substring of the operation name.
+            final int substrLength = query.length();
+            final int substrCount = text.length() - query.length() + 1;
+
+            for (int i = 0; i < substrCount; i++) {
+                final String subname = text.substring(i, i + substrLength);
+                if (StringUtils.getLevenshteinDistance(query, subname, 1) != -1) return true;
+            }
+
+            return false;
+        } else {
+            // Otherwise, just look at the distance of the two strings
+            return StringUtils.getLevenshteinDistance(query, text, 1) != -1;
+        }
+    }
+}

--- a/src/main/resources/edu/wpi/grip/ui/Palette.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/Palette.fxml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?language javascript?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.VBox?>
 <?import org.controlsfx.control.textfield.CustomTextField?>
 <fx:root fillWidth="true" styleClass="palette" type="javafx.scene.layout.VBox" xmlns="http://javafx.com/javafx/8.0.40"
-         xmlns:fx="http://javafx.com/fxml/1">
+         xmlns:fx="http://javafx.com/fxml/1" onKeyPressed="operationSearch.requestFocus()">
     <children>
         <Label styleClass="pane-title" text="Operation Palette" maxWidth="Infinity"/>
         <CustomTextField fx:id="operationSearch" promptText="Search"/>
-        <ScrollPane fx:id="palettePane" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED">
+        <ScrollPane fx:id="palettePane" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" vbarPolicy="AS_NEEDED"
+                    VBox.vgrow="ALWAYS">
             <VBox fx:id="operations"/>
         </ScrollPane>
     </children>


### PR DESCRIPTION
Searching is now "fuzzy" - it will ignore differences in whitespace,
capitalization, and small typos.  It also takes into account both the
name of an operation and its description.
The visual glitch where the bottom of a filtered operation list gets get
off if the last operation's text overflows has been fixed (we just
needed to set the ScrollPane to always grow vertically)

Typing while the palette is focused will automatically focus the search
box.

closes #113

![1](https://cloud.githubusercontent.com/assets/3964980/11162259/b8282152-8a67-11e5-8497-1c001e77b5f2.png)

![2](https://cloud.githubusercontent.com/assets/3964980/11162260/b9d90e26-8a67-11e5-8e32-bcda354908a2.png)

![3](https://cloud.githubusercontent.com/assets/3964980/11162261/bb756df6-8a67-11e5-96fe-da4d134d17d1.png)
