### PR TITLE
Add IDE plugins to buildscript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ gradle-app.setting
 # IntelliJ
 out/
 
+# Eclipse
+.classpath
+.project
+.settings/
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 
@@ -80,3 +85,4 @@ bower_components
 
 #Generated files should be ignored as the are regenerated as a build step
 src/generated
+/bin/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'eclipse'
 apply plugin: 'application'
 apply plugin: 'jacoco'
 apply from: 'http://dl.bintray.com/shemnon/javafx-gradle/8.1.1/javafx.plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,23 @@ allprojects {
     }
 }
 
+// IDE setup
+
+eclipse.classpath {
+  file.whenMerged { cp ->
+    sourceSets.generated.java.srcDirs.forEach { srcDir ->
+      def source_folder = new org.gradle.plugins.ide.eclipse.model.SourceFolder(srcDir.getAbsolutePath(), "build/classes/merged")
+      if (cp.entries.find() { it.path == source_folder.path } == null)
+        cp.entries.add(source_folder)
+    }
+  }
+}
+
+idea.module {
+  sourceDirs += sourceSets.generated.java.srcDirs
+}
+
+// End IDE setup
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.6'


### PR DESCRIPTION
Adds the ability to run ```gradlew idea``` and ```gradlew eclipse``` to setup a development environments with all dependencies linked and ready-to-go. 