### PR TITLE
Move UI layout settings from Java code to FXML where possible

### DIFF
--- a/src/main/java/edu/wpi/grip/ui/OperationView.java
+++ b/src/main/java/edu/wpi/grip/ui/OperationView.java
@@ -4,11 +4,9 @@ import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.Operation;
 import edu.wpi.grip.core.Step;
 import edu.wpi.grip.core.events.StepAddedEvent;
-import edu.wpi.grip.ui.util.DPIUtility;
 import edu.wpi.grip.ui.util.StyleClassNameUtility;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
-import javafx.fxml.Initializable;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
@@ -16,8 +14,6 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.GridPane;
 
 import java.io.IOException;
-import java.net.URL;
-import java.util.ResourceBundle;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -25,9 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * A JavaFX control that renders information about an {@link Operation}.  This is used in the palette view to present
  * the user with information on the various operations to choose from.
  */
-public class OperationView extends GridPane implements Initializable {
-    private final EventBus eventBus;
-    private final Operation operation;
+public class OperationView extends GridPane {
 
     @FXML
     private Label name;
@@ -37,6 +31,9 @@ public class OperationView extends GridPane implements Initializable {
 
     @FXML
     private ImageView icon;
+
+    private final EventBus eventBus;
+    private final Operation operation;
 
     public OperationView(EventBus eventBus, Operation operation) {
         checkNotNull(eventBus);
@@ -53,15 +50,12 @@ public class OperationView extends GridPane implements Initializable {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        this.eventBus.register(this);
-    }
 
-    @Override
-    public void initialize(URL url, ResourceBundle resourceBundle) {
+        this.eventBus.register(this);
+
         this.setId(StyleClassNameUtility.idNameFor(this.operation));
         this.name.setText(this.operation.getName());
         this.description.setText(this.operation.getDescription());
-        this.description.setMaxHeight(DPIUtility.LARGE_ICON_SIZE);
 
         final Tooltip tooltip = new Tooltip(this.operation.getDescription());
         tooltip.setPrefWidth(400.0);
@@ -72,24 +66,14 @@ public class OperationView extends GridPane implements Initializable {
 
         this.operation.getIcon().ifPresent(icon -> this.icon.setImage(new Image(icon)));
 
-        // Make the icon a fixed width and height in inches.  It would be cleaner to define this in CSS, but JavaFX
-        // doesn't allow fitWidth or fitHeight to be used from CSS, and defining it in FXML would not allow it to be
-        // set dynamically based on DPI.
-        this.icon.setFitWidth(DPIUtility.LARGE_ICON_SIZE);
-        this.icon.setFitHeight(DPIUtility.LARGE_ICON_SIZE);
-
-
-        // When the user clicks the operation, add a new step.
-        this.setOnMouseClicked(mouseEvent -> {
-            Step step = new Step(this.eventBus, this.operation);
-            this.eventBus.post(new StepAddedEvent(step));
-        });
-
-
         // Ensures that when this element is hidden that it also removes its size calculations
         this.managedProperty().bind(this.visibleProperty());
     }
 
+    @FXML
+    public void addStep() {
+        this.eventBus.post(new StepAddedEvent(new Step(this.eventBus, this.operation)));
+    }
 
     public Operation getOperation() {
         return operation;

--- a/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketView.java
@@ -4,13 +4,11 @@ import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.OutputSocket;
 import edu.wpi.grip.core.Socket;
 import edu.wpi.grip.core.SocketHint;
-import edu.wpi.grip.ui.util.DPIUtility;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Label;
 import javafx.scene.control.ToggleButton;
-import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 
@@ -82,14 +80,6 @@ public class OutputSocketView extends HBox implements Initializable {
         // Show a button to choose if we want to preview the socket or not
         this.preview.setSelected(this.socket.isPreviewed());
         this.preview.selectedProperty().addListener(value -> this.socket.setPreviewed(this.preview.isSelected()));
-
-        // Set all button icons to be the same size, regardless of screen resolution
-        final ImageView previewIcon = (ImageView) this.preview.getGraphic();
-        final ImageView publishIcon = (ImageView) this.publish.getGraphic();
-        previewIcon.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
-        previewIcon.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
-        publishIcon.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
-        publishIcon.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
 
         this.eventBus.register(this);
     }

--- a/src/main/java/edu/wpi/grip/ui/pipeline/StepView.java
+++ b/src/main/java/edu/wpi/grip/ui/pipeline/StepView.java
@@ -8,20 +8,16 @@ import edu.wpi.grip.core.events.StepMovedEvent;
 import edu.wpi.grip.core.events.StepRemovedEvent;
 import edu.wpi.grip.ui.pipeline.input.InputSocketView;
 import edu.wpi.grip.ui.pipeline.input.InputSocketViewFactory;
-import edu.wpi.grip.ui.util.DPIUtility;
 import edu.wpi.grip.ui.util.StyleClassNameUtility;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
-import javafx.fxml.Initializable;
 import javafx.scene.control.Labeled;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.VBox;
 
 import java.io.IOException;
-import java.net.URL;
-import java.util.ResourceBundle;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,7 +25,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * A JavaFX control that shows a step in the pipeline.  This control shows the name of the operation as well as a list
  * of input sockets and output sockets.
  */
-public class StepView extends VBox implements Initializable {
+public class StepView extends VBox {
+
     @FXML
     private Labeled title;
 
@@ -60,16 +57,10 @@ public class StepView extends VBox implements Initializable {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
 
-    @Override
-    public void initialize(URL url, ResourceBundle resourceBundle) {
         this.getStyleClass().add(StyleClassNameUtility.classNameFor(this.step));
         this.title.setText(this.step.getOperation().getName());
-
         this.step.getOperation().getIcon().ifPresent(icon -> this.icon.setImage(new Image(icon)));
-        this.icon.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
-        this.icon.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
 
         // Add a SocketControlView for each input socket and output socket
         for (InputSocket<?> inputSocket : this.step.getInputSockets()) {

--- a/src/main/resources/edu/wpi/grip/ui/Operation.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/Operation.fxml
@@ -1,19 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.net.*?>
-<?import javafx.scene.text.*?>
-<?import javafx.scene.control.*?>
-<?import java.lang.*?>
-<?import javafx.scene.layout.*?>
-<?import java.net.URL?>
-
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.*?>
+<?import edu.wpi.grip.ui.util.DPIUtility ?>
 <fx:root maxHeight="-Infinity" maxWidth="Infinity" minHeight="-Infinity" minWidth="NaN" styleClass="operation"
-         type="javafx.scene.layout.GridPane" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1">
+         type="javafx.scene.layout.GridPane" xmlns="http://javafx.com/javafx/null" onMouseClicked="#addStep"
+         xmlns:fx="http://javafx.com/fxml/1">
     <children>
-        <ImageView fx:id="icon" styleClass="operation-icon" GridPane.columnIndex="0" GridPane.rowSpan="2" fitHeight="0" fitWidth="0"/>
+        <ImageView fx:id="icon" styleClass="operation-icon" GridPane.columnIndex="0" GridPane.rowSpan="2">
+            <fitWidth>
+                <DPIUtility fx:constant="LARGE_ICON_SIZE"/>
+            </fitWidth>
+            <fitHeight>
+                <DPIUtility fx:constant="LARGE_ICON_SIZE"/>
+            </fitHeight>
+        </ImageView>
         <Label fx:id="name" styleClass="operation-name" GridPane.columnIndex="1" GridPane.rowIndex="0"/>
-        <Label fx:id="description" styleClass="operation-description" GridPane.columnIndex="1" GridPane.rowIndex="1" textOverrun="WORD_ELLIPSIS"/>
+        <Label fx:id="description" styleClass="operation-description" GridPane.columnIndex="1" GridPane.rowIndex="1"
+               textOverrun="WORD_ELLIPSIS">
+            <maxHeight>
+                <DPIUtility fx:constant="LARGE_ICON_SIZE"/>
+            </maxHeight>
+        </Label>
     </children>
     <columnConstraints>
         <ColumnConstraints/>

--- a/src/main/resources/edu/wpi/grip/ui/pipeline/OutputSocket.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/pipeline/OutputSocket.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
+<?import edu.wpi.grip.ui.util.DPIUtility ?>
 <fx:root styleClass="socket" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/null"
          xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER_RIGHT">
     <children>
@@ -13,6 +14,12 @@
             <graphic>
                 <ImageView>
                     <Image url="@../icons/preview.png"/>
+                    <fitWidth>
+                        <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                    </fitWidth>
+                    <fitHeight>
+                        <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                    </fitHeight>
                 </ImageView>
             </graphic>
             <tooltip>
@@ -23,6 +30,12 @@
             <graphic>
                 <ImageView>
                     <Image url="@../icons/publish.png"/>
+                    <fitWidth>
+                        <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                    </fitWidth>
+                    <fitHeight>
+                        <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                    </fitHeight>
                 </ImageView>
             </graphic>
             <tooltip>

--- a/src/main/resources/edu/wpi/grip/ui/pipeline/Step.fxml
+++ b/src/main/resources/edu/wpi/grip/ui/pipeline/Step.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
+<?import edu.wpi.grip.ui.util.DPIUtility ?>
 
 <fx:root type="javafx.scene.layout.VBox" xmlns="http://javafx.com/javafx/null"
          xmlns:fx="http://javafx.com/fxml/1" styleClass="step">
@@ -33,7 +34,14 @@
         <Separator orientation="HORIZONTAL"/>
         <Label fx:id="title" maxWidth="Infinity" styleClass="title">
             <graphic>
-                <ImageView fx:id="icon"/>
+                <ImageView fx:id="icon">
+                    <fitWidth>
+                        <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                    </fitWidth>
+                    <fitHeight>
+                        <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                    </fitHeight>
+                </ImageView>
             </graphic>
         </Label>
         <Separator orientation="HORIZONTAL"/>


### PR DESCRIPTION
There were a few places where things such as constant widths and heights and mouse handlers were defined in Java.  Defining them declaratively in the FXML "view" instead of the Java "controller" is probably better MVC practice, and it also makes the controller code less cluttered.