### PR TITLE
Add a headless build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,12 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath group: 'com.github.jengelman.gradle.plugins', name: 'shadow', version: '1.2.2'
-    }
+plugins {
+    id 'com.github.johnrengelman.shadow' version '1.2.2'
+    id 'java'
+    id 'idea'
+    id 'eclipse'
+    id 'application'
+    id 'jacoco'
 }
 
-apply plugin: 'java'
-apply plugin: 'idea'
-apply plugin: 'eclipse'
-apply plugin: 'application'
-apply plugin: 'jacoco'
-apply plugin: 'com.github.johnrengelman.shadow'
 apply from: 'http://dl.bintray.com/shemnon/javafx-gradle/8.1.1/javafx.plugin'
 
 version = '0.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,29 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath group: 'com.github.jengelman.gradle.plugins', name: 'shadow', version: '1.2.2'
+    }
+}
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'application'
 apply plugin: 'jacoco'
+apply plugin: 'com.github.johnrengelman.shadow'
 apply from: 'http://dl.bintray.com/shemnon/javafx-gradle/8.1.1/javafx.plugin'
 
-mainClassName = "edu.wpi.grip.Main"
 version = '0.1.0'
 
 javafx {
     appID = 'GRIP'
     appName = 'GRIP'
-    mainClass = mainClassName
+    mainClass = "edu.wpi.grip.ui.Main"
 }
 
+mainClassName = "edu.wpi.grip.core.Main"
 
 sourceSets {
     generated {
@@ -77,17 +87,17 @@ allprojects {
 // IDE setup
 
 eclipse.classpath {
-  file.whenMerged { cp ->
-    sourceSets.generated.java.srcDirs.forEach { srcDir ->
-      def source_folder = new org.gradle.plugins.ide.eclipse.model.SourceFolder(srcDir.getAbsolutePath(), "build/classes/merged")
-      if (cp.entries.find() { it.path == source_folder.path } == null)
-        cp.entries.add(source_folder)
+    file.whenMerged { cp ->
+        sourceSets.generated.java.srcDirs.forEach { srcDir ->
+            def source_folder = new org.gradle.plugins.ide.eclipse.model.SourceFolder(srcDir.getAbsolutePath(), "build/classes/merged")
+            if (cp.entries.find() { it.path == source_folder.path } == null)
+                cp.entries.add(source_folder)
+        }
     }
-  }
 }
 
 idea.module {
-  sourceDirs += sourceSets.generated.java.srcDirs
+    sourceDirs += sourceSets.generated.java.srcDirs
 }
 
 // End IDE setup

--- a/src/main/java/edu/wpi/grip/core/Main.java
+++ b/src/main/java/edu/wpi/grip/core/Main.java
@@ -1,0 +1,6 @@
+package edu.wpi.grip.core;
+
+public class Main {
+    public static void main(String[] args) {
+    }
+}

--- a/src/main/java/edu/wpi/grip/ui/Main.java
+++ b/src/main/java/edu/wpi/grip/ui/Main.java
@@ -1,11 +1,9 @@
-package edu.wpi.grip;
+package edu.wpi.grip.ui;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import edu.wpi.grip.core.events.FatalErrorEvent;
-import edu.wpi.grip.ui.ExceptionAlert;
 import edu.wpi.grip.ui.util.DPIUtility;
-import edu.wpi.grip.ui.MainWindowView;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Parent;

--- a/src/test/java/edu/wpi/grip/ui/MainWindowTest.java
+++ b/src/test/java/edu/wpi/grip/ui/MainWindowTest.java
@@ -1,7 +1,6 @@
 package edu.wpi.grip.ui;
 
 
-import edu.wpi.grip.Main;
 import edu.wpi.grip.core.AdditionOperation;
 import edu.wpi.grip.core.events.OperationAddedEvent;
 import javafx.stage.Stage;


### PR DESCRIPTION
You can now run `./gradlew shadowJar` to generate a runnable headless
jar.  Currently, the main method for this jar does nothing.