### PR TITLE
Make Dependencies Platform-Dependent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
-  }
-}
-
 plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.2'
     id 'java'
@@ -14,6 +5,7 @@ plugins {
     id 'eclipse'
     id 'application'
     id 'jacoco'
+    id 'com.google.osdetector' version '1.4.0'
 }
 
 apply from: 'http://dl.bintray.com/shemnon/javafx-gradle/8.1.1/javafx.plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.8'
     compile group: 'org.bytedeco', name: 'javacv', version: '1.1'
     compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1'
-    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: osdetector.classifier
+    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: osdetector.classifier.replace("osx", "macosx")
 
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
+  }
+}
+
 plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.2'
     id 'java'
@@ -8,6 +17,7 @@ plugins {
 }
 
 apply from: 'http://dl.bintray.com/shemnon/javafx-gradle/8.1.1/javafx.plugin'
+apply plugin: 'com.google.osdetector'
 
 version = '0.1.0'
 
@@ -42,11 +52,8 @@ dependencies {
     compile group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.8'
     compile group: 'org.bytedeco', name: 'javacv', version: '1.1'
     compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1'
-    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: 'linux-x86'
-    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: 'linux-x86_64'
-    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: 'macosx-x86_64'
-    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: 'windows-x86_64'
-    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: 'windows-x86'
+    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: osdetector.classifier
+
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.testfx', name: 'testfx-core', version: '4.0.+'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ plugins {
 }
 
 apply from: 'http://dl.bintray.com/shemnon/javafx-gradle/8.1.1/javafx.plugin'
-apply plugin: 'com.google.osdetector'
 
 version = '0.1.0'
 


### PR DESCRIPTION
Prevents the JavaCPP OpenCV presets being fetched for all platforms, fetching only what is required for the User's machine.