### PR TITLE
Use videoInput for webcam capture on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ repositories {
     jcenter()
 }
 
+def os = osdetector.classifier.replace("osx", "macosx")
+
 dependencies {
     compile group: 'org.controlsfx', name: 'controlsfx', version: '8.40.10'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
@@ -43,7 +45,8 @@ dependencies {
     compile group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.8'
     compile group: 'org.bytedeco', name: 'javacv', version: '1.1'
     compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1'
-    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: osdetector.classifier.replace("osx", "macosx")
+    compile group: 'org.bytedeco.javacpp-presets', name: 'opencv', version: '3.0.0-1.1', classifier: os
+    compile group: 'org.bytedeco.javacpp-presets', name: 'videoinput', version: '0.200-1.1', classifier: os
 
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
OpenCV's frame grabber framework seems to only work reliably for us on linux and osx, leading to crashes when using webcams on Windows.

Before this is merged, I'd like to get some testing done on a couple different computers and webcams.

closes #142