### PR TITLE
Show a "save" dialog instead of an "open" dialog when saving

### DIFF
--- a/src/main/java/edu/wpi/grip/ui/MainWindowView.java
+++ b/src/main/java/edu/wpi/grip/ui/MainWindowView.java
@@ -199,7 +199,7 @@ public class MainWindowView extends VBox {
 
         this.project.getFile().ifPresent(file -> fileChooser.setInitialDirectory(file.getParentFile()));
 
-        final File file = fileChooser.showOpenDialog(this.getScene().getWindow());
+        final File file = fileChooser.showSaveDialog(this.getScene().getWindow());
         if (file == null) {
             return false;
         }


### PR DESCRIPTION
From brad's email:

> And, the File Save operation is putting up a File Open dialog box on my mac so there’s no place to put the file name.
