### PR TITLE
Adds intellij settings for ensuring same runConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ gradle-app.setting
 
 ## Directory-based project format:
 .idea/
+!.idea/runConfigurations/
 # if you remove the above rule, at least ignore the following:
 
 # User-specific stuff:

--- a/.idea/runConfigurations/Main.xml
+++ b/.idea/runConfigurations/Main.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Main" type="Application" factoryName="Application" nameIsGenerated="true">
+    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+      <pattern>
+        <option name="PATTERN" value="edu.wpi.grip.ui.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <option name="MAIN_CLASS_NAME" value="edu.wpi.grip.ui.Main" />
+    <option name="VM_PARAMETERS" value="-ea" />
+    <option name="PROGRAM_PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="ENABLE_SWING_INSPECTOR" value="false" />
+    <option name="ENV_VARIABLES" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <module name="GRIP" />
+    <envs />
+    <method />
+  </configuration>
+</component>


### PR DESCRIPTION
Basically ensures that everyone is using `-ea` param when running grip.