### PR TITLE
Fix Platform.runLater() usage

### DIFF
--- a/ui/src/main/java/edu/wpi/grip/ui/pipeline/AddSourceView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/pipeline/AddSourceView.java
@@ -164,7 +164,7 @@ public class AddSourceView extends HBox {
             } catch (IOException e) {
                 // This will run it again with the new values retrieved by the supplier
                 failureCallback.accept(e);
-                Platform.runLater(() -> loadCamera(dialog, cameraSourceSupplier, failureCallback));
+                loadCamera(dialog, cameraSourceSupplier, failureCallback);
             }
         });
     }

--- a/ui/src/main/java/edu/wpi/grip/ui/pipeline/PipelineView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/pipeline/PipelineView.java
@@ -2,12 +2,12 @@ package edu.wpi.grip.ui.pipeline;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import com.sun.javafx.application.PlatformImpl;
 import edu.wpi.grip.core.*;
 import edu.wpi.grip.core.events.*;
 import edu.wpi.grip.ui.pipeline.input.InputSocketView;
 import edu.wpi.grip.ui.pipeline.source.SourceView;
 import edu.wpi.grip.ui.pipeline.source.SourceViewFactory;
-import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.collections.ObservableList;
@@ -197,7 +197,7 @@ public class PipelineView extends StackPane implements Initializable {
      * details of adding the connection.
      */
     private void addConnectionView(Connection connection) {
-        Platform.runLater(() -> {
+        PlatformImpl.runAndWait(() -> {
             // Before adding a connection control, we have to look up the controls for both sockets in the connection so
             // we know where to position it.
             final OutputSocketView outputSocketView = findOutputSocketView(connection.getOutputSocket());
@@ -218,7 +218,7 @@ public class PipelineView extends StackPane implements Initializable {
                     final double x2 = inputSocketBounds.getMinX() + inputSocketBounds.getWidth() / 2.0;
                     final double y2 = inputSocketBounds.getMinY() + inputSocketBounds.getHeight() / 2.0;
 
-                    Platform.runLater(() -> {
+                    PlatformImpl.runAndWait(() -> {
                         connectionView.inputHandleProperty().setValue(new Point2D(x1, y1));
                         connectionView.outputHandleProperty().setValue(new Point2D(x2, y2));
                         ((ReadOnlyObjectProperty) observable).get();
@@ -236,20 +236,20 @@ public class PipelineView extends StackPane implements Initializable {
 
     @Subscribe
     public void onSourceAdded(SourceAddedEvent event) {
-        Platform.runLater(() ->
+        PlatformImpl.runAndWait(() ->
                 this.sources.getChildren().add(
                         SourceViewFactory.createSourceControlsView(eventBus, event.getSource())));
     }
 
     @Subscribe
     public void onSourceRemoved(SourceRemovedEvent event) {
-        Platform.runLater(() -> this.sources.getChildren().remove(findSourceView(event.getSource())));
+        PlatformImpl.runAndWait(() -> this.sources.getChildren().remove(findSourceView(event.getSource())));
     }
 
     @Subscribe
     public void onStepAdded(StepAddedEvent event) {
         // Add a new control to the pipelineview for the step that was added
-        Platform.runLater(() -> {
+        PlatformImpl.runAndWait(() -> {
             int index = event.getIndex().or(this.steps.getChildren().size());
             this.steps.getChildren().add(index, new StepView(this.eventBus, event.getStep()));
         });
@@ -258,7 +258,7 @@ public class PipelineView extends StackPane implements Initializable {
     @Subscribe
     public void onStepRemoved(StepRemovedEvent event) {
         // Remove the control that corresponds with the step that was removed
-        Platform.runLater(() -> {
+        PlatformImpl.runAndWait(() -> {
             final StepView stepView = findStepView(event.getStep());
             this.steps.getChildren().remove(stepView);
             this.eventBus.unregister(stepView);
@@ -267,7 +267,7 @@ public class PipelineView extends StackPane implements Initializable {
 
     @Subscribe
     public void onStepMoved(StepMovedEvent event) {
-        Platform.runLater(() -> {
+        PlatformImpl.runAndWait(() -> {
             final StepView stepView = findStepView(event.getStep());
 
             final int oldIndex = this.getSteps().indexOf(stepView);
@@ -283,13 +283,13 @@ public class PipelineView extends StackPane implements Initializable {
     @Subscribe
     public void onConnectionAdded(ConnectionAddedEvent event) {
         // Add the new connection view
-        Platform.runLater(() -> this.addConnectionView(event.getConnection()));
+        PlatformImpl.runAndWait(() -> this.addConnectionView(event.getConnection()));
     }
 
     @Subscribe
     public void onConnectionRemoved(ConnectionRemovedEvent event) {
         // Remove the control that corresponds with the connection that was removed
-        Platform.runLater(() -> {
+        PlatformImpl.runAndWait(() -> {
             final ConnectionView connectionView = findConnectionView(event.getConnection());
             this.connections.getChildren().remove(connectionView);
             this.eventBus.unregister(connectionView);


### PR DESCRIPTION
Our code is not really written to handle asyncronous GUI updates in many
situations, such as updating the pipeline view when steps are
added/deleted/moved.  So, in these situations we should block the
calling thread until the GUI thread has finished performing the
specified action.

In addition, it is not necessary to call Platorm.runLater() from the GUI
thread.
