### PR TITLE
Exclude unused stuff from the jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,23 @@ project(":core") {
                 builtBy shadowJar
             }
         }
+
+        /* The icudt54b directory in Jython takes up 9 megabytes and doesn't seem to do anything useful. */
+        exclude 'org/python/icu/impl/data/icudt54b/'
+
+        /* We don't use all of the OpenCV libraries, and they seem to take up a lot of space.  If we ever decide to
+        use any more of these (or perhaps just include them for people to use from Python scripts), the following lines
+        should be changed, but for now this saves us a lot of space. */
+        exclude 'org/bytedeco/javacpp/*/*calib3d*'
+        exclude 'org/bytedeco/javacpp/*/*face*'
+        exclude 'org/bytedeco/javacpp/*/*objdetect*'
+        exclude 'org/bytedeco/javacpp/*/*optflow*'
+        exclude 'org/bytedeco/javacpp/*/*photo*'
+        exclude 'org/bytedeco/javacpp/*/*shape*'
+        exclude 'org/bytedeco/javacpp/*/*stitching*'
+        exclude 'org/bytedeco/javacpp/*/*superres*'
+        exclude 'org/bytedeco/javacpp/*/*videostab*'
+        exclude 'org/bytedeco/javacpp/*/*xfeatures2d*'
     }
 
     sourceSets {


### PR DESCRIPTION
This brings the size of the headless jar down almost 30%, which should both make the distribution smaller (and probably more likely to be downloaded by people), and make the deploy time quicker.

On my system (Linux x86_64), the core jar is now 34.3 MB instead of 48 MB.