### PR TITLE
Fixes ImageConverter running in the wrong thread

### DIFF
--- a/ui/src/main/java/edu/wpi/grip/ui/preview/BlobsSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/BlobsSocketPreviewView.java
@@ -87,10 +87,10 @@ public class BlobsSocketPreviewView extends SocketPreviewView<BlobsReport> {
                 }
             }
 
-            final Image image = this.imageConverter.convert(input);
+            final Mat inputToConvert = input;
             final int numBlobs = blobsReport.getBlobs().size();
-
             platform.runAsSoonAsPossible(() -> {
+                final Image image = this.imageConverter.convert(inputToConvert);
                 this.imageView.setImage(image);
                 this.infoLabel.setText("Found " + numBlobs + " blobs");
             });

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/ContoursSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/ContoursSocketPreviewView.java
@@ -84,9 +84,10 @@ public final class ContoursSocketPreviewView extends SocketPreviewView<ContoursR
                 }
             }
 
-            final Image image = this.imageConverter.convert(tmp);
             final long finalNumContours = numContours;
+            final Mat convertInput = tmp;
             platform.runAsSoonAsPossible(() -> {
+                final Image image = this.imageConverter.convert(convertInput);
                 this.imageView.setImage(image);
                 this.infoLabel.setText("Found " + finalNumContours + " contours");
             });

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/ImageSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/ImageSocketPreviewView.java
@@ -44,8 +44,8 @@ public class ImageSocketPreviewView extends SocketPreviewView<Mat> {
     private void convertImage() {
         synchronized (this) {
             this.getSocket().getValue().ifPresent(mat -> {
-                final Image image = this.imageConverter.convert(mat);
                 platform.runAsSoonAsPossible(() -> {
+                    final Image image = this.imageConverter.convert(mat);
                     this.imageView.setImage(image);
                 });
 

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/LinesSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/LinesSocketPreviewView.java
@@ -94,11 +94,10 @@ public class LinesSocketPreviewView extends SocketPreviewView<LinesReport> {
                     circle(input, endPoint, 2, Scalar.WHITE, 2, LINE_8, 0);
                 }
             }
-
-            final Image image = this.imageConverter.convert(input);
+            final Mat convertInput = input;
             final int numLines = lines.size();
-
             platform.runAsSoonAsPossible(() -> {
+                final Image image = this.imageConverter.convert(convertInput);
                 this.imageView.setImage(image);
                 this.infoLabel.setText("Found " + numLines + " lines");
             });

--- a/ui/src/main/java/edu/wpi/grip/ui/util/ImageConverter.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/util/ImageConverter.java
@@ -1,6 +1,7 @@
 package edu.wpi.grip.ui.util;
 
 import com.google.common.primitives.UnsignedBytes;
+import javafx.application.Platform;
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelFormat;
 import javafx.scene.image.WritableImage;
@@ -31,6 +32,16 @@ public final class ImageConverter {
      * @return A JavaFX image, or null for empty
      */
     public Image convert(Mat mat) {
+        /*
+         * IMPORTANT!
+         * The {@link ImageConverter#image} is a component that may be actively part of the UI
+         * If we are changing it while it is being rendered by the UI thread this could cause
+         * a problem in the UI thread.
+         */
+        if(!Platform.isFxApplicationThread()) {
+            throw new IllegalStateException("This modifies an FX object. This must be run in the UI Thread");
+        }
+
         final int width = mat.cols();
         final int height = mat.rows();
         final int channels = mat.channels();


### PR DESCRIPTION
If an image changed dimention in the preview pane
it's UI counterpart could be changed in the wrong thread.
This could cause random ArrayOutOfBounds Exceptions without
any context as to what was causing the problem.
This forces the ImageConverter.convert method to be run in the
UI thread or it will throw an exception.

Possibly related: #225