### PR TITLE
Fixes Handling of InterruptedExceptions

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/GRIPCoreModule.java
+++ b/core/src/main/java/edu/wpi/grip/core/GRIPCoreModule.java
@@ -16,11 +16,15 @@ import edu.wpi.grip.core.sources.ImageFileSource;
 import edu.wpi.grip.core.sources.MultiImageFileSource;
 import edu.wpi.grip.core.util.ExceptionWitness;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * A Guice {@link com.google.inject.Module} for GRIP's core package.  This is where instances of {@link Pipeline},
  * {@link Palette}, {@link Project}, etc... are created.
  */
 public class GRIPCoreModule extends AbstractModule {
+    private final Logger logger = Logger.getLogger(GRIPCoreModule.class.getName());
 
     private final EventBus eventBus = new EventBus(this::onSubscriberException);
 
@@ -60,10 +64,20 @@ public class GRIPCoreModule extends AbstractModule {
     }
 
     private void onSubscriberException(Throwable exception, SubscriberExceptionContext context) {
-        eventBus.post(new UnexpectedThrowableEvent(exception, "An event subscriber threw an exception"));
+        if (exception instanceof InterruptedException) {
+            logger.log(Level.FINE, "EventBus Subscriber threw InterruptedException", exception);
+            Thread.currentThread().interrupt();
+        } else {
+            eventBus.post(new UnexpectedThrowableEvent(exception, "An event subscriber threw an exception"));
+        }
     }
 
     private void onThreadException(Thread thread, Throwable exception) {
-        eventBus.post(new UnexpectedThrowableEvent(exception, thread + " threw an exception"));
+        if (exception instanceof InterruptedException) {
+            logger.log(Level.FINE, "InterruptedException from thread " + thread, exception);
+            Thread.currentThread().interrupt();
+        } else {
+            eventBus.post(new UnexpectedThrowableEvent(exception, thread + " threw an exception"));
+        }
     }
 }

--- a/core/src/main/java/edu/wpi/grip/core/StartStoppable.java
+++ b/core/src/main/java/edu/wpi/grip/core/StartStoppable.java
@@ -26,7 +26,7 @@ public interface StartStoppable {
      * @throws TimeoutException If the thread fails to stop in a timely manner
      * @throws IOException      If cleaning up some system resource fails.
      */
-    void stop() throws TimeoutException, IOException;
+    void stop() throws InterruptedException, TimeoutException, IOException;
 
     /**
      * Used to indicate if the source is running or stopped

--- a/core/src/main/java/edu/wpi/grip/core/Step.java
+++ b/core/src/main/java/edu/wpi/grip/core/Step.java
@@ -143,7 +143,9 @@ public class Step {
 
         try {
             this.operation.perform(inputSockets, outputSockets, data);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
+            // We do not want to catch all exceptions, only runtime exceptions.
+            // This is especially important when it comes to InterruptedExceptions
             final String operationFailedMessage = "The " + operation.getName() + " operation did not perform correctly.";
             logger.log(Level.WARNING, operationFailedMessage, e);
             witness.flagException(e, operationFailedMessage);

--- a/core/src/main/java/edu/wpi/grip/core/util/ExceptionWitness.java
+++ b/core/src/main/java/edu/wpi/grip/core/util/ExceptionWitness.java
@@ -48,10 +48,16 @@ public class ExceptionWitness {
     /**
      * Indicates to the witness that an exception has occurred. This will also post an {@link ExceptionEvent} to the {@link EventBus}
      *
-     * @param exception The exception that this is reporting
+     * @param exception The exception that this is reporting.
+     *                  If the Exception is an InterruptedException then this will not post an exception, instead,
+     *                  it will set the threads interrupted state and return.
      * @param message   Any additional details that should be associated with this message.
      */
     public final void flagException(final Exception exception, final String message) {
+        if (exception instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+            return;
+        }
         isExceptionState.set(true);
         this.eventBus.post(new ExceptionEvent(origin, exception, message));
     }

--- a/ui/src/main/java/edu/wpi/grip/ui/components/StartStoppableButton.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/components/StartStoppableButton.java
@@ -64,6 +64,9 @@ public final class StartStoppableButton extends ToggleButton {
                 // If this fails then an StartedStoppedEvent will not be posted
             } catch (TimeoutException | IOException e) {
                 eventBus.post(new UnexpectedThrowableEvent(e, "Failed to stop"));
+            } catch (InterruptedException e) {
+                // Unfortunately we have to eat the exception here because we can't rethrow it
+                Thread.currentThread().interrupt();
             }
         });
 

--- a/ui/src/test/java/edu/wpi/grip/ui/util/GRIPPlatformTest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/util/GRIPPlatformTest.java
@@ -14,6 +14,7 @@ import org.testfx.framework.junit.ApplicationTest;
 
 import java.util.logging.Logger;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class GRIPPlatformTest extends ApplicationTest {
@@ -74,6 +75,17 @@ public class GRIPPlatformTest extends ApplicationTest {
             waiter.resume();
         });
         waiter.await();
+    }
+
+    @Test
+    public void testRunAsSoonAsPossibleWillNotCallIfInterrupted() throws Exception {
+        final boolean hasRun [] = {false};
+
+        Thread.currentThread().interrupt();
+        platform.runAsSoonAsPossible(() -> {
+            hasRun[0] = true;
+        });
+        assertFalse("runAsSoonAsPossible ran when interrupted", hasRun[0]);
     }
 
 }


### PR DESCRIPTION
Before we treated InterruptedExceptions just like every other
type of exception. This is bad because it means that the thread
that had been asked to exit was having to go through the process
of displaying a UI component which was causing deadlocks.

Closes #236