### PR TITLE
Fix various deployment problems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,10 @@ project(":core") {
         compile group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.8'
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
         compile group: 'com.google.guava', name: 'guava', version: '18.0'
-        compile group: 'com.google.inject', name: 'guice', version: '4.0'
+        // We use the no_aop version of Guice because the aop isn't avaiable in arm java
+        // http://stackoverflow.com/a/15235190/3708426
+        // https://github.com/google/guice/wiki/OptionalAOP
+        compile group: 'com.google.inject', name: 'guice', version: '4.0', classifier: 'no_aop'
         compile group: 'com.google.inject.extensions', name: 'guice-assistedinject', version: '4.0'
     }
 

--- a/core/src/main/java/edu/wpi/grip/core/Main.java
+++ b/core/src/main/java/edu/wpi/grip/core/Main.java
@@ -28,7 +28,9 @@ public class Main {
     @Inject
     private Logger logger;
 
+    @SuppressWarnings("PMD.SystemPrintln")
     public static void main(String[] args) throws IOException, InterruptedException {
+        System.out.println("Loading Dependency Injection Framework");
         final Injector injector = Guice.createInjector(new GRIPCoreModule());
         injector.getInstance(Main.class).start(args);
     }
@@ -38,30 +40,9 @@ public class Main {
         if (args.length != 1) {
             System.err.println("Usage: GRIP.jar project.grip");
             return;
+        } else {
+            logger.log(Level.INFO, "Loading file " + args[0]);
         }
-
-        //Set up the global level logger. This handles IO for all loggers.
-        Logger globalLogger = LogManager.getLogManager().getLogger("");//This is our global logger
-
-        Handler fileHandler = null;//This will be our handler for the global logger
-
-        try {
-            fileHandler = new FileHandler("%h/GRIP.log");//Log to the file "GRIPlogger.log"
-
-            globalLogger.addHandler(fileHandler);//Add the handler to the global logger
-
-            fileHandler.setFormatter(new SimpleFormatter());//log in text, not xml
-
-            //Set level to handler and logger
-            fileHandler.setLevel(Level.FINE);
-            globalLogger.setLevel(Level.FINE);
-
-            globalLogger.config("Configuration done.");//Log that we are done setting up the logger
-
-        } catch (IOException exception) {//Something happened setting up file IO
-            throw new IllegalStateException(exception);
-        }
-
 
         Operations.addOperations(eventBus);
         CVOperations.addOperations(eventBus);
@@ -73,7 +54,7 @@ public class Main {
 
 
         // This is done in order to indicate to the user using the deployment UI that this is running
-        System.out.println("SUCCESS! The project is running in headless mode!");
+        logger.log(Level.INFO, "SUCCESS! The project is running in headless mode!");
         // There's nothing more to do in the main thread since we're in headless mode - sleep forever
         for (; ; ) {
             Thread.sleep(Integer.MAX_VALUE);

--- a/ui/src/main/java/edu/wpi/grip/ui/DeployerController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/DeployerController.java
@@ -55,13 +55,13 @@ public class DeployerController {
         }
 
         public StreamToTextArea reset() {
-            outputArea.clear();
+            Platform.runLater(outputArea::clear);
             return this;
         }
 
         @Override
         public void write(int i) throws IOException {
-            outputArea.appendText(String.valueOf((char) i));
+            Platform.runLater(()-> outputArea.appendText(String.valueOf((char) i)));
         }
     }
 

--- a/ui/src/main/java/edu/wpi/grip/ui/Main.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/Main.java
@@ -20,8 +20,6 @@ import javafx.scene.image.Image;
 import javafx.stage.Stage;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.util.logging.*;
 
 public class Main extends Application {
 
@@ -53,29 +51,6 @@ public class Main extends Application {
     @Override
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public void start(Stage stage) throws Exception {
-
-        //Set up the global level logger. This handles IO for all loggers.
-        Logger globalLogger = LogManager.getLogManager().getLogger("");//This is our global logger
-
-        Handler fileHandler = null;//This will be our handler for the global logger
-
-        try {
-            fileHandler = new FileHandler("%h/GRIP.log");//Log to the file "GRIP.log"
-
-            globalLogger.addHandler(fileHandler);//Add the handler to the global logger
-
-            fileHandler.setFormatter(new SimpleFormatter());//log in text, not xml
-
-            //Set level to handler and logger
-            fileHandler.setLevel(Level.FINE);
-            globalLogger.setLevel(Level.FINE);
-
-            globalLogger.config("Configuration done.");//Log that we are done setting up the logger
-
-        } catch (IOException exception) {//Something happened setting up file IO
-            throw new IllegalStateException(exception);
-        }
-
         root = FXMLLoader.load(Main.class.getResource("MainWindow.fxml"), null, null, injector::getInstance);
         root.setStyle("-fx-font-size: " + DPIUtility.FONT_SIZE + "px");
 

--- a/ui/src/main/java/edu/wpi/grip/ui/util/deployment/DeployedInstanceManager.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/util/deployment/DeployedInstanceManager.java
@@ -180,6 +180,7 @@ public class DeployedInstanceManager implements StartStoppable {
                 synchronized (this) {
                     sshThread = Optional.empty();
                 }
+                eventBus.post(new StartedStoppedEvent(this));
             }
         }, "SSH Monitor Thread");
         launcher.setUncaughtExceptionHandler((thread, exception) -> {
@@ -216,7 +217,6 @@ public class DeployedInstanceManager implements StartStoppable {
             }
             runStop();
         } while (isStarted() && !Thread.interrupted());
-        eventBus.post(new StartedStoppedEvent(this));
     }
 
     /**


### PR DESCRIPTION
- ARM Java does not support aop so we need to change what guice we are using
- Deploying can throw null pointers because writing text to the text box was
not in the UI thread.
- Logging was setup after the guice injector was loaded meaning problems with
injecting wouldn't be logged.
- The GRIPCore module assumed that the main file would be registered on the
event bus to log exceptions but it isn't until after the injector is created.
- The thread that manages starting GRIP on a remote device does not actually 
post a startstopped event if the shell crashes