### PR TITLE
Add getTypeLabel() method to SocketHint

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/NoSocketTypeLabel.java
+++ b/core/src/main/java/edu/wpi/grip/core/NoSocketTypeLabel.java
@@ -1,0 +1,18 @@
+package edu.wpi.grip.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * By default, the GUI shows labels for the type of each socket based on {@link Class#getSimpleName()}.  This is useful
+ * as a hint to the user of what connections would be valid (type-safe) to make.  However, for some types this
+ * information is kind of useless, since the type is either named almost exactly the same as the identifier (for
+ * example, MySettingsEnum/MySettings), or the type is just so long that it gets cut off in the UI and it's probably
+ * just best to not include it.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface NoSocketTypeLabel {
+}

--- a/core/src/main/java/edu/wpi/grip/core/SocketHint.java
+++ b/core/src/main/java/edu/wpi/grip/core/SocketHint.java
@@ -3,11 +3,13 @@ package edu.wpi.grip.core;
 import com.google.common.base.MoreObjects;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.bytedeco.javacpp.opencv_core.Mat;
 
 /**
  * A <code>SocketHint</code> is a descriptor that gives some information about one of the inputs or outputs of an
@@ -54,6 +56,22 @@ public class SocketHint<T> {
 
     public Optional<T[]> getDomain() {
         return domain;
+    }
+
+    /**
+     * @return A user-presentable string to represent the type of this socket.  This may be empty.
+     */
+    public String getTypeLabel() {
+        if (type.getAnnotation(NoSocketTypeLabel.class) != null || type.isEnum() || type.equals(List.class)) {
+            // Enums labels are kind of redundant, and Lists actually represent ranges
+            return "";
+        } else if (Mat.class.equals(type)) {
+            // "Mats" represent images
+            return "Image";
+        } else {
+            // For any other type, just use the name of the class
+            return type.getSimpleName();
+        }
     }
 
     public Optional<T> createInitialValue() {

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/BlobsReport.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/BlobsReport.java
@@ -1,6 +1,7 @@
 package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.base.MoreObjects;
+import edu.wpi.grip.core.NoSocketTypeLabel;
 import edu.wpi.grip.core.operations.networktables.NTPublishable;
 import edu.wpi.grip.core.operations.networktables.NTValue;
 
@@ -12,6 +13,7 @@ import static org.bytedeco.javacpp.opencv_core.Mat;
 /**
  * This class is used as the output of operations that detect blobs in an image
  */
+@NoSocketTypeLabel
 public class BlobsReport implements NTPublishable {
     private final Mat input;
     private final List<Blob> blobs;

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/ContoursReport.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/ContoursReport.java
@@ -1,5 +1,6 @@
 package edu.wpi.grip.core.operations.composite;
 
+import edu.wpi.grip.core.NoSocketTypeLabel;
 import edu.wpi.grip.core.operations.networktables.NTPublishable;
 import edu.wpi.grip.core.operations.networktables.NTValue;
 
@@ -15,6 +16,7 @@ import static org.bytedeco.javacpp.opencv_imgproc.contourArea;
  * OpenCV objects, as well as the width and height of the image that the contours are from, to give context to the
  * points.
  */
+@NoSocketTypeLabel
 public final class ContoursReport implements NTPublishable {
     private final int rows, cols;
     private final MatVector contours;

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/LinesReport.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/LinesReport.java
@@ -1,5 +1,7 @@
 package edu.wpi.grip.core.operations.composite;
 
+import edu.wpi.grip.core.NoSocketTypeLabel;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,6 +17,7 @@ import static org.bytedeco.javacpp.opencv_imgproc.createLineSegmentDetector;
  * and line filtering operations) to have a type-safe way of operating on line detection results and not just any
  * random matrix.
  */
+@NoSocketTypeLabel
 public class LinesReport {
     private Mat input = new Mat();
     private List<Line> lines = new ArrayList<>();

--- a/ui/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/pipeline/OutputSocketController.java
@@ -76,7 +76,7 @@ public class OutputSocketController implements Controller {
 
         // Set the label on the control based on the identifier from the socket hint
         this.identifier.setText(socketHint.getIdentifier());
-        this.type.setText(socketHint.getType().getSimpleName());
+        this.type.setText(this.socket.getSocketHint().getTypeLabel());
     }
 
     public Socket getSocket() {

--- a/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/InputSocketController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/InputSocketController.java
@@ -64,9 +64,7 @@ public class InputSocketController<T> implements Controller {
     @FXML
     public void initialize() {
         this.identifier.setText(this.socket.getSocketHint().getIdentifier());
-        if (!(this.socket.getSocketHint().getType().isEnum())) {
-            this.type.setText(this.socket.getSocketHint().getType().getSimpleName());
-        }
+        this.type.setText(this.socket.getSocketHint().getTypeLabel());
         this.handle = socketHandleViewFactory.create(this.socket);
         root.add(this.handle, 0, 0);
     }


### PR DESCRIPTION
Instead of just using the raw class name, the GUI now calls this method
to the label for the type of a socket.  This lets us override the class
name in different ways in the core, fixing some layout issues with
really long labels.