### PR TITLE
Speeds UP CI Builds

### DIFF
--- a/.travis-scripts/push-javadoc-to-gh-pages.sh
+++ b/.travis-scripts/push-javadoc-to-gh-pages.sh
@@ -3,6 +3,9 @@
 # Source of file: http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 if [ "$TRAVIS_REPO_SLUG" == "WPIRoboticsProjects/GRIP" ] && [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
 
+  echo -e "Generating javadoc...\n"
+  ./gradlew aggregateJavadocs
+
   echo -e "Publishing javadoc...\n"
 
   cp -R build/docs/javadoc $HOME/javadoc-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,15 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - pip install --user codecov
 
-install: ./gradlew :ui:assemble --stacktrace
+# Only do an assemble when we aren't building a pull request
+install:
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew :ui:assemble --stacktrace || ./gradlew --stacktrace '
 
-after_failure: #Run again with debug info enabled
-  - ./gradlew check  --stacktrace -PprintTestResults
+script:
+  - ./gradlew check --stacktrace -PprintTestResults
 
 after_success:
   - codecov
-  - ./gradlew aggregateJavadocs
   - .travis-scripts/push-javadoc-to-gh-pages.sh
   - .travis-scripts/before-deploy.sh
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/WPIRoboticsProjects/GRIP](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/WPIRoboticsProjects/GRIP?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/WPIRoboticsProjects/GRIP.svg?branch=master)](https://travis-ci.org/WPIRoboticsProjects/GRIP)
-[![Build status](https://ci.appveyor.com/api/projects/status/9xl8pggec4l75pqb/branch/master?svg=true)](https://ci.appveyor.com/project/ThomasJClark/grip/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/sbrd2nhpiktlhf58/branch/master?svg=true)](https://ci.appveyor.com/project/JLLeitschuh/grip/branch/master)
 [![codecov.io](http://codecov.io/github/WPIRoboticsProjects/GRIP/coverage.svg?branch=master)](http://codecov.io/github/WPIRoboticsProjects/GRIP?branch=master)
 [![Github Releases](https://img.shields.io/github/downloads/WPIRoboticsProjects/GRIP/total.svg)](https://github.com/WPIRoboticsProjects/GRIP/releases/latest)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ install:
   - choco install -y InnoSetup
 
 build_script:
-  - gradlew.bat :ui:assemble --stacktrace
+  - gradlew.bat --stacktrace
 
 # to run your custom scripts instead of automatic tests
 test_script:
@@ -11,11 +11,11 @@ test_script:
 platform:
   - x64
 
-after_build:
-  - dir build /s
-
 artifacts:
   - path: ui\build\distributions\*.exe
+
+before_deploy:
+  - gradlew.bat :ui:assemble --stacktrace -PprintTestResults
 
 deploy:
   provider: GitHub


### PR DESCRIPTION
 - Makes it so `:ui:assemble` only happens on deploy
  - Appveyor now completes in ~ 8 min instead of 12
  - Travis now completes in ~ 4 min instead of ~ 6 min
 - Moves JavaDoc generation to only happen on merge with master