### PR TITLE
Network tables is now only initialized when set as network protocol

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/Main.java
+++ b/core/src/main/java/edu/wpi/grip/core/Main.java
@@ -27,6 +27,8 @@ public class Main {
     private EventBus eventBus;
     @Inject
     private Logger logger;
+    @Inject
+    private Operations operations;
 
     @SuppressWarnings("PMD.SystemPrintln")
     public static void main(String[] args) throws IOException, InterruptedException {
@@ -44,7 +46,7 @@ public class Main {
             logger.log(Level.INFO, "Loading file " + args[0]);
         }
 
-        Operations.addOperations(eventBus);
+        operations.addOperations(eventBus);
         CVOperations.addOperations(eventBus);
 
         final String projectPath = args[0];

--- a/core/src/main/java/edu/wpi/grip/core/operations/Operations.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/Operations.java
@@ -1,19 +1,27 @@
 package edu.wpi.grip.core.operations;
 
 import com.google.common.eventbus.EventBus;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import edu.wpi.grip.core.events.OperationAddedEvent;
 import edu.wpi.grip.core.operations.composite.*;
+import edu.wpi.grip.core.operations.networktables.NTManager;
 import edu.wpi.grip.core.operations.networktables.NTPublishOperation;
 import edu.wpi.grip.core.operations.opencv.MatFieldAccessor;
 import edu.wpi.grip.core.operations.opencv.MinMaxLoc;
 import edu.wpi.grip.core.operations.opencv.NewPointOperation;
 import edu.wpi.grip.core.operations.opencv.NewSizeOperation;
 
-public final class Operations {
+@Singleton
+public class Operations {
 
-    private Operations() { /* no op */}
+    private final NTManager ntManager;
+    @Inject
+    Operations(NTManager ntManager) {
+        this.ntManager = ntManager;
+    }
 
-    public static void addOperations(EventBus eventBus) {
+    public void addOperations(EventBus eventBus) {
         // Add the default built-in operations to the palette
         eventBus.post(new OperationAddedEvent(new BlurOperation()));
         eventBus.post(new OperationAddedEvent(new DesaturateOperation()));
@@ -31,8 +39,8 @@ public final class Operations {
         eventBus.post(new OperationAddedEvent(new NewPointOperation()));
         eventBus.post(new OperationAddedEvent(new NewSizeOperation()));
         eventBus.post(new OperationAddedEvent(new MatFieldAccessor()));
-        eventBus.post(new OperationAddedEvent(new NTPublishOperation<>(ContoursReport.class)));
-        eventBus.post(new OperationAddedEvent(new NTPublishOperation<>(BlobsReport.class)));
-        eventBus.post(new OperationAddedEvent(new NTPublishOperation<>(LinesReport.class)));
+        eventBus.post(new OperationAddedEvent(new NTPublishOperation<>(ContoursReport.class, ntManager::getBaseTable)));
+        eventBus.post(new OperationAddedEvent(new NTPublishOperation<>(BlobsReport.class, ntManager::getBaseTable)));
+        eventBus.post(new OperationAddedEvent(new NTPublishOperation<>(LinesReport.class, ntManager::getBaseTable)));
     }
 }

--- a/core/src/test/java/edu/wpi/grip/core/operations/OperationsTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/operations/OperationsTest.java
@@ -6,6 +6,7 @@ import com.google.common.eventbus.Subscribe;
 import edu.wpi.grip.core.Operation;
 import edu.wpi.grip.core.Step;
 import edu.wpi.grip.core.events.OperationAddedEvent;
+import edu.wpi.grip.core.operations.networktables.MockNTManager;
 import edu.wpi.grip.core.util.MockExceptionWitness;
 import edu.wpi.grip.generated.CVOperations;
 import org.junit.After;
@@ -20,6 +21,12 @@ public class OperationsTest {
     private List<Operation> operationList;
     private Optional<Throwable> throwableOptional;
     private EventBus eventBus;
+
+    public static class OperationsWithMockNTManager extends Operations {
+        public OperationsWithMockNTManager() {
+            super(new MockNTManager());
+        }
+    }
 
     private class OperationGrabber {
         @Subscribe
@@ -55,7 +62,7 @@ public class OperationsTest {
 
     @Test
     public void testCreateAllCoreSteps() {
-        Operations.addOperations(eventBus);
+        new OperationsWithMockNTManager().addOperations(eventBus);
         for (Operation operation : operationList) {
             new Step.Factory(eventBus, (origin) -> new MockExceptionWitness(eventBus, origin)).create(operation);
         }

--- a/core/src/test/java/edu/wpi/grip/core/operations/networktables/MockNTManager.java
+++ b/core/src/test/java/edu/wpi/grip/core/operations/networktables/MockNTManager.java
@@ -1,0 +1,10 @@
+package edu.wpi.grip.core.operations.networktables;
+
+/**
+ * Mock instance of the NTManager to be used in tests
+ */
+public class MockNTManager extends NTManager {
+    public MockNTManager() {
+        super(null, () -> null);
+    }
+}

--- a/ui/src/main/java/edu/wpi/grip/ui/Main.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/Main.java
@@ -12,6 +12,7 @@ import edu.wpi.grip.core.operations.Operations;
 import edu.wpi.grip.core.util.SafeShutdown;
 import edu.wpi.grip.generated.CVOperations;
 import edu.wpi.grip.ui.util.DPIUtility;
+import edu.wpi.grip.ui.util.GRIPPlatform;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
@@ -32,6 +33,10 @@ public class Main extends Application {
     private Palette palette;
     @Inject
     private Logger logger;
+    @Inject
+    private GRIPPlatform platform;
+    @Inject
+    private Operations operations;
 
     protected final Injector injector = Guice.createInjector(new GRIPCoreModule(), new GRIPUIModule());
 
@@ -56,7 +61,7 @@ public class Main extends Application {
         root = FXMLLoader.load(Main.class.getResource("MainWindow.fxml"), null, null, injector::getInstance);
         root.setStyle("-fx-font-size: " + DPIUtility.FONT_SIZE + "px");
 
-        Operations.addOperations(eventBus);
+        operations.addOperations(eventBus);
         CVOperations.addOperations(eventBus);
 
         stage.setOnCloseRequest((event) -> {

--- a/ui/src/test/java/edu/wpi/grip/ui/pipeline/input/InputSocketControllerFactoryTest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/pipeline/input/InputSocketControllerFactoryTest.java
@@ -4,7 +4,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import edu.wpi.grip.core.*;
-import edu.wpi.grip.core.operations.Operations;
+import edu.wpi.grip.core.operations.OperationsTest;
 import edu.wpi.grip.generated.CVOperations;
 import edu.wpi.grip.ui.GRIPUIModule;
 import javafx.scene.Scene;
@@ -30,7 +30,7 @@ public class InputSocketControllerFactoryTest extends ApplicationTest {
         Injector injector = Guice.createInjector(new GRIPCoreModule());
         final Palette palette = injector.getInstance(Palette.class);
         final EventBus eventBus = injector.getInstance(EventBus.class);
-        Operations.addOperations(eventBus);
+        new OperationsTest.OperationsWithMockNTManager().addOperations(eventBus);
         CVOperations.addOperations(eventBus);
         Collection<Operation> operations = palette.getOperations();
 


### PR DESCRIPTION
If you have a NetworkTables operation in your pipeline and your
network protocol is not set correctly network tables operations
will now fail.

<img width="1074" alt="screenshot 2016-01-07 19 53 29" src="https://cloud.githubusercontent.com/assets/1323708/12193156/763b4f22-b5b3-11e5-90e9-febc4b8abbee.png">


Closes #313