### PR TITLE
Don't automatically start up NetworkTables

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/networktables/NTPublishOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/networktables/NTPublishOperation.java
@@ -28,8 +28,11 @@ public class NTPublishOperation<T extends NTPublishable> implements Operation {
     private final List<Method> ntValueMethods = new ArrayList<>();
 
     public NTPublishOperation(Class<T> type) {
-        this.table = NetworkTable.getTable("GRIP");
         this.type = checkNotNull(type, "Type was null");
+
+        // NetworkTables automatically initializes itself when we get a table.  We don't want this behavior.
+        table = NetworkTable.getTable("GRIP");
+        NetworkTable.shutdown();
 
         // Any accessor method with an @NTValue annotation can be published to NetworkTables.
         for (Method method : type.getDeclaredMethods()) {


### PR DESCRIPTION
NetworkTables initializes itself automatically as soon as we create a table, which we do basically as soon as GRIP starts up.  This is kind of annoying because it creates a lot of noise in the logs when we're not actually using NetworkTables.

We can simply undo this by immediately calling `NetworkTables::shutdown()`, and it will only start back up again if we explicitly set the project settings to use NetworkTables.
