### PR TITLE
Check for number of channels in threshold operations

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/HSLThresholdOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/HSLThresholdOperation.java
@@ -20,7 +20,7 @@ import static org.bytedeco.javacpp.opencv_imgproc.cvtColor;
  * An {@link edu.wpi.grip.core.Operation} that converts a color image into a binary image based on the HSL threshold ranges
  */
 public class HSLThresholdOperation extends ThresholdOperation {
-    private static final Logger logger =  Logger.getLogger(HSLThresholdOperation.class.getName());
+    private static final Logger logger = Logger.getLogger(HSLThresholdOperation.class.getName());
     private final SocketHint<Mat> inputHint = SocketHints.Inputs.createMatSocketHint("Input", false);
     private final SocketHint<List> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 180.0);
     private final SocketHint<List> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 255.0);
@@ -63,6 +63,10 @@ public class HSLThresholdOperation extends ThresholdOperation {
         final List<Number> channel1 = ((InputSocket<List<Number>>) inputs[1]).getValue().get();
         final List<Number> channel2 = ((InputSocket<List<Number>>) inputs[2]).getValue().get();
         final List<Number> channel3 = ((InputSocket<List<Number>>) inputs[3]).getValue().get();
+
+        if (input.channels() != 3) {
+            throw new IllegalArgumentException("HSL Threshold needs a 3-channel input");
+        }
 
         final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
         final Mat output = outputSocket.getValue().get();

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/HSVThresholdOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/HSVThresholdOperation.java
@@ -22,7 +22,7 @@ import static org.bytedeco.javacpp.opencv_imgproc.cvtColor;
  */
 public class HSVThresholdOperation extends ThresholdOperation {
 
-    private static final Logger logger =  Logger.getLogger(HSVThresholdOperation.class.getName());
+    private static final Logger logger = Logger.getLogger(HSVThresholdOperation.class.getName());
     private final SocketHint<Mat> inputHint = SocketHints.Inputs.createMatSocketHint("Input", false);
     private final SocketHint<List> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 180.0);
     private final SocketHint<List> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 255.0);
@@ -66,6 +66,10 @@ public class HSVThresholdOperation extends ThresholdOperation {
         final List<Number> channel1 = ((InputSocket<List<Number>>) inputs[1]).getValue().get();
         final List<Number> channel2 = ((InputSocket<List<Number>>) inputs[2]).getValue().get();
         final List<Number> channel3 = ((InputSocket<List<Number>>) inputs[3]).getValue().get();
+
+        if (input.channels() != 3) {
+            throw new IllegalArgumentException("HSV Threshold needs a 3-channel input");
+        }
 
         final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
         final Mat output = outputSocket.getValue().get();

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/RGBThresholdOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/RGBThresholdOperation.java
@@ -15,7 +15,7 @@ import static org.bytedeco.javacpp.opencv_core.*;
  */
 public class RGBThresholdOperation extends ThresholdOperation {
 
-    private static final Logger logger =  Logger.getLogger(RGBThresholdOperation.class.getName());
+    private static final Logger logger = Logger.getLogger(RGBThresholdOperation.class.getName());
     private final SocketHint<Mat> inputHint = SocketHints.Inputs.createMatSocketHint("Input", false);
     private final SocketHint<List> redHint = SocketHints.Inputs.createNumberListRangeSocketHint("Red", 0.0, 255.0);
     private final SocketHint<List> greenHint = SocketHints.Inputs.createNumberListRangeSocketHint("Green", 0.0, 255.0);
@@ -64,6 +64,10 @@ public class RGBThresholdOperation extends ThresholdOperation {
         final List<Number> channel1 = ((InputSocket<List<Number>>) inputs[1]).getValue().get();
         final List<Number> channel2 = ((InputSocket<List<Number>>) inputs[2]).getValue().get();
         final List<Number> channel3 = ((InputSocket<List<Number>>) inputs[3]).getValue().get();
+
+        if (input.channels() != 3) {
+            throw new IllegalArgumentException("RGB Threshold needs a 3-channel input");
+        }
 
         final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
         final Mat output = outputSocket.getValue().get();


### PR DESCRIPTION
inRange segfaults if we give it three channels of ranges but a single
channel image.  Throwing an IllegalArgumentException is not ideal, but
it's better than segfaulting.

Closes #178
Related #250