### PR TITLE
Revert "Don't automatically start up NetworkTables"

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/networktables/NTPublishOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/networktables/NTPublishOperation.java
@@ -28,11 +28,8 @@ public class NTPublishOperation<T extends NTPublishable> implements Operation {
     private final List<Method> ntValueMethods = new ArrayList<>();
 
     public NTPublishOperation(Class<T> type) {
+        this.table = NetworkTable.getTable("GRIP");
         this.type = checkNotNull(type, "Type was null");
-
-        // NetworkTables automatically initializes itself when we get a table.  We don't want this behavior.
-        table = NetworkTable.getTable("GRIP");
-        NetworkTable.shutdown();
 
         // Any accessor method with an @NTValue annotation can be published to NetworkTables.
         for (Method method : type.getDeclaredMethods()) {


### PR DESCRIPTION
Reverts WPIRoboticsProjects/GRIP#311
This is an invalid fix.
This should not be merged this way.
I don't care if it bothered you. You do not get to make the executive decision on how this is fixed..