### PR TITLE
Exception alert enhancements

### DIFF
--- a/ui/src/main/java/edu/wpi/grip/ui/ExceptionAlert.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/ExceptionAlert.java
@@ -32,7 +32,7 @@ public final class ExceptionAlert extends Alert {
     };
 
     private static final ButtonType COPY = new ButtonType("Copy to Clipboard");
-    private static final ButtonType GITHUB = new ButtonType("Open GitHub Issues");
+    private static final ButtonType REPORT = new ButtonType("Report Issue");
 
     private final Node initialFocusElement;
 
@@ -63,8 +63,7 @@ public final class ExceptionAlert extends Alert {
         this.setResizable(true);
 
         // Add two additional buttons
-        this.getButtonTypes().removeIf((buttonType) -> buttonType.equals(ButtonType.OK));
-        this.getButtonTypes().addAll(COPY, closeBtnType, GITHUB);
+        this.getButtonTypes().setAll(COPY, closeBtnType, REPORT);
 
 
         final GridPane dialogContent = new GridPane();
@@ -100,7 +99,7 @@ public final class ExceptionAlert extends Alert {
             event.consume(); // Prevent the dialog from closing
         });
 
-        final Button openGitHubIssueBtn = (Button) this.getDialogPane().lookupButton(GITHUB);
+        final Button openGitHubIssueBtn = (Button) this.getDialogPane().lookupButton(REPORT);
         openGitHubIssueBtn.addEventFilter(ActionEvent.ACTION, event -> {
             services.showDocument(PROJECT_ISSUE_LINK);
             event.consume(); // Prevent the dialog from closing

--- a/ui/src/main/resources/edu/wpi/grip/ui/GRIP.css
+++ b/ui/src/main/resources/edu/wpi/grip/ui/GRIP.css
@@ -193,3 +193,11 @@ VBox.sockets {
     -fx-hgap: 4em;
     -fx-vgap: 1em;
 }
+
+.exception-pane {
+    -fx-vgap: 1em;
+}
+
+.exception-text {
+    -fx-font-family: "Monospace";
+}


### PR DESCRIPTION
GitHub's servers (and many modern browsers) apparently don't like us redirecting users to thousand-character-long URLs to automatically fill in issue forms.  So, I got rid of that whole thing and just put the generated text in the exception alert.  Users can copy and paste it themselves.

The list of system properties was also updated to remove some redundant/useless ones.  We can always ask for more info if necessary, but the ones removed can all be derived from existing ones.  This should just clear up some visual clutter.

The lack of styling in the alert has also bothered me for a while, so that's fixed now.

Closes #330