### PR TITLE
Fix windows hanging when being shutdown

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/events/UnexpectedThrowableEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/UnexpectedThrowableEvent.java
@@ -1,5 +1,7 @@
 package edu.wpi.grip.core.events;
 
+import edu.wpi.grip.core.util.SafeShutdown;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -50,7 +52,7 @@ public final class UnexpectedThrowableEvent {
             try {
                 logger.log(Level.SEVERE, "Failed to handle safely", throwable);
             } finally {
-                System.exit(1);
+                SafeShutdown.exit(1);
             }
         } finally {
             shutdownIfFatal();
@@ -67,7 +69,7 @@ public final class UnexpectedThrowableEvent {
                 logger.log(Level.SEVERE, "Shutting down from error", throwable);
             } finally {
                 // If all else fails then shutdown
-                System.exit(1);
+                SafeShutdown.exit(1);
             }
         }
     }

--- a/core/src/main/java/edu/wpi/grip/core/util/SafeShutdown.java
+++ b/core/src/main/java/edu/wpi/grip/core/util/SafeShutdown.java
@@ -1,0 +1,84 @@
+package edu.wpi.grip.core.util;
+
+/**
+ * This class should be used to shutdown GRIP safely.
+ * This is because shutdown hooks may throw exceptions, as such
+ * we need to know if the application being is shutdown.
+ */
+public final class SafeShutdown {
+
+    public static volatile boolean stopping = false;
+
+    static {
+        /*
+         * Shutdown hook run order is non-deterministic but this increases our likelihood of flagging a shutdown
+         * that we can't control.
+         */
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                stopping = true;
+            }
+        });
+    }
+
+    /**
+     * Shutdown's the VM in such a way that flags that the vm is stopping.
+     * This is so that we don't run the normal exception handling code when
+     * shutting down the application.
+     *
+     * @param statusCode exit status.
+     * @param hook       The hook to run before the System shutdown.
+     *                   This will be run after stopping has been flagged true.
+     *                   This is nullable.
+     * @see System#exit(int)
+     */
+    public static final void exit(int statusCode, PreSystemExitHook hook) {
+        flagStopping();
+        try {
+            if (hook != null) {
+                hook.run();
+            }
+        } finally {
+            System.exit(statusCode);
+        }
+
+    }
+
+    /**
+     * Helper method that passes null as the PreSystemExitHook.
+     *
+     * @param statusCode exit status.
+     * @see #exit(int)
+     */
+    public static final void exit(int statusCode) {
+        exit(statusCode, null);
+    }
+
+
+    /**
+     * HACK!
+     * Shutdown hooks can throw exceptions.
+     * On Windows, the static method after {@link org.bytedeco.javacpp.Loader#loadLibrary} throws such an exception
+     * in a shutdown hook.
+     *
+     * @return True if if the application is shutting down.
+     * @see <a href="https://github.com/WPIRoboticsProjects/GRIP/issues/297">GRIP Issue</a>
+     * @see <a href="https://github.com/bytedeco/javacpp/issues/60">Bytedeco issue</a>
+     */
+    public static final boolean isStopping() {
+        return stopping;
+    }
+
+    /**
+     * Flags that the application is shutting down.
+     */
+    public static void flagStopping() {
+        stopping = true;
+    }
+
+    @FunctionalInterface
+    public interface PreSystemExitHook {
+        void run();
+    }
+}


### PR DESCRIPTION
This was caused because a shtdown hook threw an exception.
Our main application is designed to try to handle threads dying by
displaying a UI element. This should not be done in a shutdown hook.
What we have to do is ensure that when we try dto display the
exception alert it isn't from inside a shutdown hook.

Closes #297