### PR TITLE
Fix/generator not passing exceptions to ui

### DIFF
--- a/buildSrc/src/main/java/edu/wpi/gripgenerator/templates/Operation.java
+++ b/buildSrc/src/main/java/edu/wpi/gripgenerator/templates/Operation.java
@@ -190,39 +190,38 @@ public class Operation {
         List<Statement> performStatement = expressionList.stream().map(ExpressionStmt::new).collect(Collectors.toList());
         final String exceptionVariable = "e";
         final String outputSocketForEachVariableId = "outputSocket";
-        final TryStmt performTry = new TryStmt(
-                new BlockStmt(
-                        Arrays.asList(
+
+        performStatement.addAll(
+                Arrays.asList(
                                 /* Make the operation function call */
-                                new ExpressionStmt(
-                                        getFunctionCallExpression()
-                                ),
+                        new ExpressionStmt(
+                                getFunctionCallExpression()
+                        ),
                                 /*
                                  * Afterwards iterate over all of the output sockets and call setValue using the value
                                  * stored.
                                  */
-                                new ForeachStmt(
-                                        new VariableDeclarationExpr(
-                                                0,
-                                                ASTHelper.createReferenceType("OutputSocket", 0),
-                                                Collections.singletonList(
-                                                        new VariableDeclarator(
-                                                                new VariableDeclaratorId(outputSocketForEachVariableId)
-                                                        )
+                        new ForeachStmt(
+                                new VariableDeclarationExpr(
+                                        0,
+                                        ASTHelper.createReferenceType("OutputSocket", 0),
+                                        Collections.singletonList(
+                                                new VariableDeclarator(
+                                                        new VariableDeclaratorId(outputSocketForEachVariableId)
                                                 )
-                                        ),
-                                        new NameExpr(outputParamId),
-                                        new BlockStmt(
-                                                Collections.singletonList(
-                                                        new ExpressionStmt(
-                                                                new MethodCallExpr(
-                                                                        new NameExpr(outputSocketForEachVariableId),
-                                                                        "setValueOptional",
-                                                                        Collections.singletonList(
-                                                                                new MethodCallExpr(
-                                                                                        new NameExpr(outputSocketForEachVariableId),
-                                                                                        "getValue"
-                                                                                )
+                                        )
+                                ),
+                                new NameExpr(outputParamId),
+                                new BlockStmt(
+                                        Collections.singletonList(
+                                                new ExpressionStmt(
+                                                        new MethodCallExpr(
+                                                                new NameExpr(outputSocketForEachVariableId),
+                                                                "setValueOptional",
+                                                                Collections.singletonList(
+                                                                        new MethodCallExpr(
+                                                                                new NameExpr(outputSocketForEachVariableId),
+                                                                                "getValue"
                                                                         )
                                                                 )
                                                         )
@@ -230,36 +229,10 @@ public class Operation {
                                         )
                                 )
                         )
-                ),
-                Collections.singletonList(
-                        new CatchClause(
-                                new MultiTypeParameter(
-                                        ModifierSet.FINAL,
-                                        null,
-                                        Collections.singletonList(
-                                                ASTHelper.createReferenceType("Exception", 0)
-                                        ),
-                                        new VariableDeclaratorId(exceptionVariable)
-                                ),
-                                new BlockStmt(
-                                        // TODO: Add some sort of indication that an error has occurred
-                                        Collections.singletonList(
-                                                new ExpressionStmt(
-                                                        new MethodCallExpr(
-                                                                new NameExpr(exceptionVariable),
-                                                                "printStackTrace"
-                                                        )
-                                                )
-                                        )
-                                )
-                        )
-                ),
-                null
+                )
         );
-        // This is needed to prevent a null pointer
-        performTry.setResources(Collections.emptyList());
 
-        performStatement.add(performTry);
+
         return performStatement;
     }
 

--- a/ui/src/main/java/edu/wpi/grip/ui/components/ExceptionWitnessResponderButton.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/components/ExceptionWitnessResponderButton.java
@@ -107,8 +107,13 @@ public final class ExceptionWitnessResponderButton extends Button {
             errorMessage.setText(errorMessageText);
             if (event.getException().isPresent()) {
                 final Exception exception = event.getException().get();
-                stackTrace.setText(Throwables.getStackTraceAsString(exception));
-                stackTrace.setVisible(true);
+                final String exceptionMessage = Throwables.getStackTraceAsString(exception);
+                // Otherwise it is impossible to scroll the text field because it is updated so frequently
+                if (!exceptionMessage.equals(stackTrace.getText())) {
+                    stackTrace.setText(exceptionMessage);
+                }
+
+                stackTracePane.setVisible(true);
             } else {
                 stackTracePane.setVisible(false);
                 stackTrace.setText("");


### PR DESCRIPTION
### Generated operations no longer catch exceptions internally

They now pass them up to the step that called perform so
that it can handle it.

Closes #250


### Fixes ExceptionWitness being impossible to scroll

The UI was updating at such a high frequency that it was
impossible to scroll the stack trace pane.
Now only updates the pane when the stack trace changes.