### PR TITLE
Deploy button for the 'FRC Advanced' section of the 'FRC Deploy' dialog is enabled by default.

### DIFF
--- a/ui/src/main/java/edu/wpi/grip/ui/deployment/FRCAdvancedDeploymentOptionsController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/deployment/FRCAdvancedDeploymentOptionsController.java
@@ -61,7 +61,7 @@ public class FRCAdvancedDeploymentOptionsController extends DeploymentOptionsCon
                 getDeployButton().setDisable(false);
             }
         });
-        getDeployButton().setDisable(true);
+        getDeployButton().setDisable(false);
 
         final Label textFieldInput = new Label("Address/IP:");
         textFieldInput.setLabelFor(this.address);

--- a/ui/src/main/java/edu/wpi/grip/ui/deployment/FRCAdvancedDeploymentOptionsController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/deployment/FRCAdvancedDeploymentOptionsController.java
@@ -61,7 +61,7 @@ public class FRCAdvancedDeploymentOptionsController extends DeploymentOptionsCon
                 getDeployButton().setDisable(false);
             }
         });
-        getDeployButton().setDisable(false);
+        getDeployButton().setDisable("".equals(projectAddress));
 
         final Label textFieldInput = new Label("Address/IP:");
         textFieldInput.setLabelFor(this.address);


### PR DESCRIPTION
Changed FRCAdvancedDeploymentOptionsController->postInit() so that the deploy button for the 'FRC Advanced' section of the 'FRC Deploy' dialog is enabled by default.

This closes issue #343.