### PR TITLE
Fixes stopped camera exception stop pipeline event

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/sources/CameraSource.java
+++ b/core/src/main/java/edu/wpi/grip/core/sources/CameraSource.java
@@ -334,8 +334,10 @@ public class CameraSource extends Source implements StartStoppable {
      * @param event
      */
     @Subscribe
-    public synchronized void onStopPipeline(StopPipelineEvent event) throws InterruptedException, IOException, TimeoutException {
-        this.stop();
+    public void onStopPipeline(StopPipelineEvent event) throws InterruptedException, IOException, TimeoutException {
+        if (this.isStarted()) {
+            this.stop();
+        }
     }
 
 }

--- a/core/src/test/java/edu/wpi/grip/core/sources/CameraSourceTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/sources/CameraSourceTest.java
@@ -7,6 +7,7 @@ import com.google.common.eventbus.Subscribe;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import edu.wpi.grip.core.GRIPCoreModule;
+import edu.wpi.grip.core.events.StopPipelineEvent;
 import edu.wpi.grip.core.events.UnexpectedThrowableEvent;
 import edu.wpi.grip.core.util.MockExceptionWitness;
 import org.bytedeco.javacpp.indexer.Indexer;
@@ -184,6 +185,13 @@ public class CameraSourceTest {
             cameraSourceWithMockGrabber.stop();
         }
         fail("The test should have failed with an IllegalStateException");
+    }
+
+
+    @Test
+    public void testStopPipelineEventDoesntThrowWhenCameraStopped() throws Exception {
+        cameraSourceWithMockGrabber.onStopPipeline(new StopPipelineEvent());
+        assertFalse("The camera source should not be running", cameraSourceWithMockGrabber.isStarted());
     }
 
 }


### PR DESCRIPTION
This fixes an issue where the onStopPipeline event
would throw an exception if the camera source was
already stopped.

Closes #353