### PR TITLE
Adds save dirty checking event

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/events/ConnectionAddedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/ConnectionAddedEvent.java
@@ -9,7 +9,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event that occurs when a new connection is added to the pipeline.  This is triggered by the user adding a
  * connection with the GUI.
  */
-public class ConnectionAddedEvent implements RunPipelineEvent {
+public class ConnectionAddedEvent implements RunPipelineEvent, DirtiesSaveEvent {
     private final Connection connection;
 
     /**

--- a/core/src/main/java/edu/wpi/grip/core/events/ConnectionRemovedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/ConnectionRemovedEvent.java
@@ -9,7 +9,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event that occurs when a connection is removed from the pipeline.  This is triggered by the user deleting a
  * connection with the GUI.
  */
-public class ConnectionRemovedEvent {
+public class ConnectionRemovedEvent implements DirtiesSaveEvent {
     private final Connection connection;
 
     /**

--- a/core/src/main/java/edu/wpi/grip/core/events/DirtiesSaveEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/DirtiesSaveEvent.java
@@ -1,0 +1,18 @@
+package edu.wpi.grip.core.events;
+
+/**
+ * An event that can potentially dirty the save file.
+ * These events ensure that anything that changes causes the save file to be flagged as dirty and in need of being
+ * saved for the project to be deemed "clean" again.
+ */
+public interface DirtiesSaveEvent {
+
+    /**
+     * Some events may have more logic regarding whether they make the save dirty or not.
+     *
+     * @return True if this event should dirty the project save
+     */
+    default boolean doesDirtySave() {
+        return true;
+    }
+}

--- a/core/src/main/java/edu/wpi/grip/core/events/SocketChangedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/SocketChangedEvent.java
@@ -9,7 +9,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event that occurs when the value stored in a socket changes.  This can happen, for example, as the result of an
  * operation completing, or as a response to user input.
  */
-public class SocketChangedEvent implements RunPipelineEvent {
+public class SocketChangedEvent implements RunPipelineEvent, DirtiesSaveEvent {
     private final Socket socket;
 
     /**
@@ -25,6 +25,18 @@ public class SocketChangedEvent implements RunPipelineEvent {
      */
     public Socket getSocket() {
         return this.socket;
+    }
+
+    /**
+     * This event will only dirty the save if the InputSocket does not have connections.
+     * Thus the value can only have been changed by a UI component.
+     * If the socket has connections then the value change is triggered by another socket's change.
+     *
+     * @return True if this should dirty the save.
+     */
+    @Override
+    public boolean doesDirtySave() {
+        return socket.getDirection() == Socket.Direction.INPUT && socket.getConnections().isEmpty();
     }
 
     @Override

--- a/core/src/main/java/edu/wpi/grip/core/events/SocketPreviewChangedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/SocketPreviewChangedEvent.java
@@ -9,7 +9,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event that occurs when a {@link OutputSocket} is set to be either previewed or not previewed.  The GUI listens for these events
  * so it knows which sockets to show previews for.
  */
-public class SocketPreviewChangedEvent {
+public class SocketPreviewChangedEvent implements DirtiesSaveEvent {
     private OutputSocket socket;
 
     /**

--- a/core/src/main/java/edu/wpi/grip/core/events/SourceAddedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/SourceAddedEvent.java
@@ -12,7 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @see Source
  */
-public class SourceAddedEvent {
+public class SourceAddedEvent implements DirtiesSaveEvent {
     private final Source source;
 
     /**

--- a/core/src/main/java/edu/wpi/grip/core/events/SourceRemovedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/SourceRemovedEvent.java
@@ -12,7 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @see Source
  */
-public class SourceRemovedEvent {
+public class SourceRemovedEvent implements DirtiesSaveEvent {
     private final Source source;
 
     /**

--- a/core/src/main/java/edu/wpi/grip/core/events/StepAddedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/StepAddedEvent.java
@@ -13,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event that occurs when a new step is added to the pipeline.  This is triggered by the user adding a step with the
  * GUI.
  */
-public class StepAddedEvent {
+public class StepAddedEvent implements DirtiesSaveEvent {
     private final Step step;
     private final OptionalInt index;
 

--- a/core/src/main/java/edu/wpi/grip/core/events/StepMovedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/StepMovedEvent.java
@@ -8,7 +8,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * An event that occurs when a new step is moved from one position to another in the pipeline
  */
-public class StepMovedEvent {
+public class StepMovedEvent implements DirtiesSaveEvent {
     private final Step step;
     private final int distance;
 

--- a/core/src/main/java/edu/wpi/grip/core/events/StepRemovedEvent.java
+++ b/core/src/main/java/edu/wpi/grip/core/events/StepRemovedEvent.java
@@ -9,7 +9,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event that occurs when a new step is removed from the pipeline.  This is triggered by the user deleting a step
  * from the GUI.
  */
-public class StepRemovedEvent {
+public class StepRemovedEvent implements DirtiesSaveEvent {
     private final Step step;
 
     /**

--- a/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
@@ -85,7 +85,7 @@ public class MainWindowController {
      * @return true If the user has not chosen to
      */
     private boolean showConfirmationDialogAndWait() {
-        if (!pipeline.getSteps().isEmpty()) {
+        if (!pipeline.getSteps().isEmpty() && project.isSaveDirty()) {
             final ButtonType save = new ButtonType("Save");
             final ButtonType dontSave = ButtonType.NO;
             final ButtonType cancel = ButtonType.CANCEL;


### PR DESCRIPTION
This provides a cleaner UI experience.
You are now only requested to save when an event dirties the save file.
The deployer now also ensures that you have not dirtied the save.