### PR TITLE
Fixes Desaturate Feeding back into the previous step

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/DesaturateOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/DesaturateOperation.java
@@ -54,7 +54,7 @@ public class DesaturateOperation implements Operation {
         switch (input.channels()) {
             case 1:
                 // If the input is already one channel, it's already desaturated
-                output = input;
+                input.copyTo(output);
                 break;
 
             case 3:


### PR DESCRIPTION
This was caused by not copying the input to the output
and just simply assigning the value of the input to the
output.

Closes #252

I actually had a comment on that line when this code was introduced but the comment was never resolved.
https://github.com/WPIRoboticsProjects/GRIP/pull/63/files#r43678331
Any way this can be prevented in the future?