### PR TITLE
Add solidity filter

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/ContoursReport.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/ContoursReport.java
@@ -6,10 +6,8 @@ import edu.wpi.grip.core.operations.networktables.NTValue;
 
 import java.util.Optional;
 
-import static org.bytedeco.javacpp.opencv_core.MatVector;
-import static org.bytedeco.javacpp.opencv_core.Rect;
-import static org.bytedeco.javacpp.opencv_imgproc.boundingRect;
-import static org.bytedeco.javacpp.opencv_imgproc.contourArea;
+import static org.bytedeco.javacpp.opencv_core.*;
+import static org.bytedeco.javacpp.opencv_imgproc.*;
 
 /**
  * The output of {@link FindContoursOperation}.  This stores a list of contours (which is basically a list of points) in
@@ -112,5 +110,16 @@ public final class ContoursReport implements NTPublishable {
             heights[i] = boundingBoxes[i].height();
         }
         return heights;
+    }
+
+    @NTValue(key = "solidity")
+    public synchronized double[] getSolidity() {
+        final double[] solidities = new double[(int) contours.size()];
+        Mat hull = new Mat();
+        for (int i = 0; i < contours.size(); i++) {
+            convexHull(contours.get(i), hull);
+            solidities[i] = contourArea(contours.get(i)) / contourArea(hull);
+        }
+        return solidities;
     }
 }


### PR DESCRIPTION
This lets you filter contours by their "solidity", which is the ratio of their area to the area of their convex hull. 

You can technically filter out false positives by just having a minimum area, but that means that actual targets will be filtered out if you're too far away from them.  In addition, larger false positives will still show up.

The FIRST Stronghold targets have a solidity of about 1/3 regardless of how far away they are, so using a solidity filter gets them very reliably.

![demo](https://cloud.githubusercontent.com/assets/3964980/12374565/47739d78-bc6d-11e5-9c66-de7ba29ba37a.png)