### PR TITLE
v1.1.0 for real

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,19 +16,6 @@ plugins {
 apply plugin: 'nebula-aggregate-javadocs'
 
 
-/*
- * Gets the version name from the latest Git tag
- * http://ryanharter.com/blog/2013/07/30/automatic-versioning-with-git-and-gradle/
- */
-def getVersionName = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim().substring(1)
-}
-
 allprojects {
     apply plugin: 'java'
     apply plugin: 'application'
@@ -50,7 +37,7 @@ allprojects {
         testCompile group: 'junit', name: 'junit', version: '4.12'
     }
 
-    version = getVersionName()
+    version = '1.1.0'
 
     compileJava {
         options.compilerArgs << "-g"


### PR DESCRIPTION
We **cannot** use `git describe` to generate versions, since you can't
just use any arbitrary string as the version with JavaFX's packaging
tools.  .deb and .rpm builds both fail if you do this on a commit that
isn't tagged, or is tagged in a way other than v1.1.0 (for example,
release candidates)