### PR TITLE
Add JVM args and more options to the deploy dialog

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
+++ b/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
@@ -31,6 +31,9 @@ public class ProjectSettings implements Cloneable {
     @Setting(label = "Deploy Java home", description = "Where Java is installed on the robot.")
     private String deployJavaHome = "/usr/local/frc/JRE/";
 
+    @Setting(label = "Deploy JVM options", description = "Command line options passed to the roboRIO JVM")
+    private String deployJvmOptions = "-Xmx50m";
+
     /**
      * Set the FRC team number.  If the deploy address and NetworkTables server address haven't been manually
      * overridden, this also changes them to the mDNS hostname of the team's roboRIO.
@@ -98,6 +101,14 @@ public class ProjectSettings implements Cloneable {
         if (deployJavaHome != null) this.deployJavaHome = deployJavaHome;
     }
 
+    public String getDeployJvmOptions() {
+        return deployJvmOptions;
+    }
+
+    public void setDeployJvmOptions(String deployJvmOptions) {
+        this.deployJvmOptions = deployJvmOptions;
+    }
+
     private String computeFRCAddress(int teamNumber) {
         return "roborio-" + teamNumber + "-frc.local";
     }
@@ -109,6 +120,7 @@ public class ProjectSettings implements Cloneable {
                 .add("deployDir", deployDir)
                 .add("deployUser", deployUser)
                 .add("deployJavaHome", deployJavaHome)
+                .add("deployJvmOptions", deployJvmOptions)
                 .add("publishAddress", publishAddress)
                 .add("teamNumber", teamNumber)
                 .toString();

--- a/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
+++ b/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
@@ -106,7 +106,7 @@ public class ProjectSettings implements Cloneable {
     }
 
     public void setDeployJvmOptions(String deployJvmOptions) {
-        this.deployJvmOptions = deployJvmOptions;
+        if (deployJvmOptions != null) this.deployJvmOptions = deployJvmOptions;
     }
 
     private String computeFRCAddress(int teamNumber) {

--- a/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
+++ b/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
@@ -32,7 +32,7 @@ public class ProjectSettings implements Cloneable {
     private String deployJavaHome = "/usr/local/frc/JRE/";
 
     @Setting(label = "Deploy JVM options", description = "Command line options passed to the roboRIO JVM")
-    private String deployJvmOptions = "-Xmx50m";
+    private String deployJvmOptions = "-Xmx50m -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError";
 
     /**
      * Set the FRC team number.  If the deploy address and NetworkTables server address haven't been manually

--- a/ui/src/main/java/edu/wpi/grip/ui/DeployController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/DeployController.java
@@ -12,7 +12,6 @@ import edu.wpi.grip.ui.util.StringInMemoryFile;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import net.schmizz.sshj.SSHClient;
@@ -55,22 +54,19 @@ public class DeployController {
     @FXML private TextField deployDir;
     @FXML private ProgressIndicator progress;
     @FXML private Label command;
-    @FXML private Button deployButton;
     @FXML private Label status;
     @FXML private TextArea console;
+    @FXML private BooleanProperty deploying;
 
     @Inject private EventBus eventBus;
     @Inject private Project project;
     @Inject private Pipeline pipeline;
-
     @Inject private Logger logger;
-    private final BooleanProperty deploying = new SimpleBooleanProperty(this, "deploying", false);
+
     private Optional<Thread> deployThread = Optional.empty();
 
     @FXML
     public void initialize() {
-        deployButton.disableProperty().bind(deploying);
-        progress.disableProperty().bind(deploying.not());
         deploying.addListener((o, b, d) -> progress.setProgress(d ? ProgressIndicator.INDETERMINATE_PROGRESS : 0));
         command.textProperty().bind(Bindings.concat(javaHome.textProperty(), "/bin/java ", jvmArgs.textProperty(),
                 " -jar '", deployDir.textProperty(), "/", GRIP_JAR, "' '", deployDir.textProperty(), "/", PROJECT_FILE, "'"));

--- a/ui/src/main/java/edu/wpi/grip/ui/DeployController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/DeployController.java
@@ -115,7 +115,7 @@ public class DeployController {
         console.clear();
 
         // Start the deploy in a new thread, so the GUI doesn't freeze
-        deployThread = Optional.of(new Thread(this::deploy));
+        deployThread = Optional.of(new Thread(this::deploy, "Deploy"));
         deployThread.get().setDaemon(true);
         deployThread.get().start();
     }

--- a/ui/src/main/java/edu/wpi/grip/ui/DeployController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/DeployController.java
@@ -47,7 +47,6 @@ import java.util.logging.Logger;
 public class DeployController {
     private final static String GRIP_JAR = "grip.jar";
     private final static String GRIP_WRAPPER = "grip";
-    private final static String PROJECT_FILE = "project.grip";
     private final static String LOCAL_GRIP_JAR = URLDecoder.decode(
             Project.class.getProtectionDomain().getCodeSource().getLocation().getPath());
 
@@ -57,6 +56,7 @@ public class DeployController {
     @FXML private TextField javaHome;
     @FXML private TextField jvmArgs;
     @FXML private TextField deployDir;
+    @FXML private TextField projectFile;
     @FXML private ProgressIndicator progress;
     @FXML private Label status;
     @FXML private TextArea console;
@@ -74,7 +74,7 @@ public class DeployController {
     public void initialize() {
         deploying.addListener((o, b, d) -> progress.setProgress(d ? ProgressIndicator.INDETERMINATE_PROGRESS : 0));
         command.bind(Bindings.concat(javaHome.textProperty(), "/bin/java ", jvmArgs.textProperty(), " -jar '",
-                deployDir.textProperty(), "/", GRIP_JAR, "' '", deployDir.textProperty(), "/", PROJECT_FILE, "'"));
+                deployDir.textProperty(), "/", GRIP_JAR, "' '", deployDir.textProperty(), "/", projectFile.textProperty(), "'"));
 
         loadSettings(pipeline.getProjectSettings());
     }
@@ -162,7 +162,7 @@ public class DeployController {
             final String pathStr = deployDir.getText() + "/";
             scp.upload(new FileSystemFile(LOCAL_GRIP_JAR), pathStr + GRIP_JAR);
             scp.upload(new StringInMemoryFile(GRIP_WRAPPER, "echo \"" + commandStr + "\"\n" + commandStr, 0755), pathStr);
-            scp.upload(new StringInMemoryFile(PROJECT_FILE, projectWriter.toString()), pathStr);
+            scp.upload(new StringInMemoryFile(projectFile.getText(), projectWriter.toString()), pathStr);
 
             // Stop the pipeline before running it remotely, so the two instances of GRIP don't try to publish to the
             // same NetworkTables keys.

--- a/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
@@ -196,6 +196,8 @@ public class MainWindowController {
         graphic.setFitWidth(DPIUtility.SMALL_ICON_SIZE);
         graphic.setFitHeight(DPIUtility.SMALL_ICON_SIZE);
 
+        deployPane.requestFocus();
+
         Dialog<ButtonType> dialog = new Dialog<>();
         dialog.setTitle("Deploy");
         dialog.setHeaderText("Deploy");

--- a/ui/src/main/java/edu/wpi/grip/ui/util/StringInMemoryFile.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/util/StringInMemoryFile.java
@@ -12,11 +12,17 @@ import java.io.StringBufferInputStream;
  */
 public class StringInMemoryFile extends InMemorySourceFile {
     private final String name, contents;
+    private final int permissions;
 
-    public StringInMemoryFile(String name, String contents) {
+    public StringInMemoryFile(String name, String contents, int permissions) {
         super();
         this.name = name;
         this.contents = contents;
+        this.permissions = permissions;
+    }
+
+    public StringInMemoryFile(String name, String contents) {
+        this(name, contents, 0644);
     }
 
     @Override
@@ -27,6 +33,11 @@ public class StringInMemoryFile extends InMemorySourceFile {
     @Override
     public long getLength() {
         return contents.getBytes().length;
+    }
+
+    @Override
+    public int getPermissions() {
+        return permissions;
     }
 
     @Override

--- a/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
@@ -11,6 +11,10 @@
 <VBox styleClass="deploy-pane" maxWidth="Infinity" xmlns:fx="http://javafx.com/fxml/1"
       onKeyPressed="if (event.code == javafx.scene.input.KeyCode.ENTER) { controller.onDeploy() }"
       xmlns="http://javafx.com/javafx/null" fx:controller="edu.wpi.grip.ui.DeployController">
+    <fx:define>
+        <SimpleBooleanProperty fx:id="deploying"/>
+    </fx:define>
+
     <GridPane maxHeight="Infinity">
         <columnConstraints>
             <ColumnConstraints hgrow="NEVER" halignment="RIGHT"/>
@@ -59,6 +63,7 @@
         <buttons>
             <Button fx:id="deployButton" defaultButton="true" onMouseClicked="#onDeploy" text="Deploy"
                     ButtonBar.buttonData="APPLY">
+                <fx:script>deployButton.disableProperty().bind(deploying)</fx:script>
                 <graphic>
                     <ImageView styleClass="menu-graphic">
                         <fitWidth>
@@ -78,7 +83,9 @@
     </ButtonBar>
 
     <StackPane>
-        <ProgressBar fx:id="progress" maxWidth="Infinity" progress="0"/>
+        <ProgressBar fx:id="progress" maxWidth="Infinity" progress="0">
+            <fx:script>progress.disableProperty().bind(deploying.not())</fx:script>
+        </ProgressBar>
         <Label fx:id="status"/>
     </StackPane>
 

--- a/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
@@ -2,6 +2,7 @@
 
 <?language javascript?>
 
+<?import edu.wpi.grip.ui.DeployController?>
 <?import edu.wpi.grip.ui.util.DPIUtility?>
 <?import javafx.beans.property.SimpleBooleanProperty?>
 <?import javafx.beans.property.SimpleStringProperty?>
@@ -36,6 +37,10 @@
             <PasswordField disable="${deployButton.disabled}" fx:id="password" promptText="Password"
                            GridPane.columnIndex="1" GridPane.rowIndex="2"/>
 
+            <Label disable="${deployButton.disabled}" text="Project File" GridPane.columnIndex="0"
+                   GridPane.rowIndex="3"/>
+            <TextField disable="${deployButton.disabled}" fx:id="projectFile" promptText="Project File"
+                       GridPane.columnIndex="1" GridPane.rowIndex="3" text="project.grip"/>
         </GridPane>
         <Separator orientation="VERTICAL" HBox.hgrow="NEVER" visible="false">
             <prefWidth>
@@ -61,33 +66,34 @@
                    GridPane.rowIndex="2"/>
             <TextField disable="${deployButton.disabled}" fx:id="jvmArgs" promptText="JVM Arguments"
                        GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+
+            <ButtonBar GridPane.columnIndex="0" GridPane.rowIndex="3" GridPane.columnSpan="2">
+                <buttons>
+                    <Button fx:id="deployButton" defaultButton="true" onMouseClicked="#onDeploy" text="Deploy"
+                            ButtonBar.buttonData="APPLY">
+                        <fx:script>deployButton.disableProperty().bind(deploying)</fx:script>
+                        <graphic>
+                            <ImageView styleClass="menu-graphic">
+                                <fitWidth>
+                                    <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                                </fitWidth>
+                                <fitHeight>
+                                    <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+                                </fitHeight>
+                                <image>
+                                    <Image url="@icons/deploy.png"/>
+                                </image>
+                            </ImageView>
+                        </graphic>
+                    </Button>
+                    <Button text="Stop" ButtonBar.buttonData="CANCEL_CLOSE" onMouseClicked="#onStop"/>
+                </buttons>
+            </ButtonBar>
+
         </GridPane>
     </HBox>
 
     <Separator orientation="HORIZONTAL" VBox.vgrow="NEVER"/>
-
-    <ButtonBar>
-        <buttons>
-            <Button fx:id="deployButton" defaultButton="true" onMouseClicked="#onDeploy" text="Deploy"
-                    ButtonBar.buttonData="APPLY">
-                <fx:script>deployButton.disableProperty().bind(deploying)</fx:script>
-                <graphic>
-                    <ImageView styleClass="menu-graphic">
-                        <fitWidth>
-                            <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
-                        </fitWidth>
-                        <fitHeight>
-                            <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
-                        </fitHeight>
-                        <image>
-                            <Image url="@icons/deploy.png"/>
-                        </image>
-                    </ImageView>
-                </graphic>
-            </Button>
-            <Button text="Stop" ButtonBar.buttonData="CANCEL_CLOSE" onMouseClicked="#onStop"/>
-        </buttons>
-    </ButtonBar>
 
     <StackPane>
         <ProgressBar fx:id="progress" maxWidth="Infinity" progress="0">

--- a/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
@@ -1,18 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?language javascript ?>
+<?language javascript?>
 
 <?import edu.wpi.grip.ui.util.DPIUtility?>
-<?import edu.wpi.grip.ui.DeployController?>
+<?import javafx.beans.property.SimpleBooleanProperty?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
 <VBox styleClass="deploy-pane" maxWidth="Infinity" xmlns:fx="http://javafx.com/fxml/1"
+      onKeyPressed="if (event.code == javafx.scene.input.KeyCode.ENTER) { controller.onDeploy() }"
       xmlns="http://javafx.com/javafx/null" fx:controller="edu.wpi.grip.ui.DeployController">
     <GridPane maxHeight="Infinity">
         <columnConstraints>
-            <ColumnConstraints hgrow="NEVER"/>
+            <ColumnConstraints hgrow="NEVER" halignment="RIGHT"/>
+            <ColumnConstraints hgrow="ALWAYS"/>
+            <ColumnConstraints hgrow="NEVER">
+                <prefWidth>
+                    <DPIUtility fx:constant="FONT_SIZE"/>
+                </prefWidth>
+            </ColumnConstraints>
+            <ColumnConstraints hgrow="NEVER" halignment="RIGHT"/>
             <ColumnConstraints hgrow="ALWAYS"/>
         </columnConstraints>
 
@@ -21,22 +29,31 @@
                    GridPane.rowIndex="0"/>
 
         <Label disable="${deployButton.disabled}" text="User" GridPane.columnIndex="0" GridPane.rowIndex="1"/>
-        <TextField disable="${deployButton.disabled}" fx:id="user" promptText="User" GridPane.columnIndex="1"
+        <TextField disable="${deployButton.disabled}" fx:id="user" promptText="Username" GridPane.columnIndex="1"
                    GridPane.rowIndex="1"/>
 
         <Label disable="${deployButton.disabled}" text="Password" GridPane.columnIndex="0" GridPane.rowIndex="2"/>
         <PasswordField disable="${deployButton.disabled}" fx:id="password" promptText="Password"
                        GridPane.columnIndex="1" GridPane.rowIndex="2"/>
 
-        <Label disable="${deployButton.disabled}" text="Java Home" GridPane.columnIndex="0" GridPane.rowIndex="3"/>
-        <TextField disable="${deployButton.disabled}" fx:id="javaHome" promptText="Java Home"
-                   GridPane.columnIndex="1" GridPane.rowIndex="3"/>
-
-        <Label disable="${deployButton.disabled}" text="Deploy Directory" GridPane.columnIndex="0"
-               GridPane.rowIndex="4"/>
+        <Label disable="${deployButton.disabled}" text="Deploy Directory" GridPane.columnIndex="3"
+               GridPane.rowIndex="0"/>
         <TextField disable="${deployButton.disabled}" fx:id="deployDir" promptText="Deploy Directory"
-                   GridPane.columnIndex="1" GridPane.rowIndex="4"/>
+                   GridPane.columnIndex="4" GridPane.rowIndex="0"/>
+
+        <Label disable="${deployButton.disabled}" text="Java Home" GridPane.columnIndex="3" GridPane.rowIndex="1"/>
+        <TextField disable="${deployButton.disabled}" fx:id="javaHome" promptText="Java Home"
+                   GridPane.columnIndex="4" GridPane.rowIndex="1"/>
+
+        <Label disable="${deployButton.disabled}" text="JVM Arguments" GridPane.columnIndex="3" GridPane.rowIndex="2"/>
+        <TextField disable="${deployButton.disabled}" fx:id="jvmArgs" promptText="JVM Arguments"
+                   GridPane.columnIndex="4" GridPane.rowIndex="2"/>
+
+        <Label disable="${deployButton.disabled}" text="Command" GridPane.columnIndex="0" GridPane.rowIndex="3"/>
+        <Label fx:id="command" disable="${deployButton.disabled}" GridPane.columnIndex="1" GridPane.columnSpan="4"
+               GridPane.rowIndex="3" style="-fx-font-family: monospace"/>
     </GridPane>
+
 
     <ButtonBar>
         <buttons>
@@ -65,5 +82,5 @@
         <Label fx:id="status"/>
     </StackPane>
 
-    <TextArea fx:id="console" editable="false" styleClass="console" prefRowCount="24" prefColumnCount="80"/>
+    <TextArea fx:id="console" editable="false" styleClass="console" prefRowCount="24" prefColumnCount="100"/>
 </VBox>

--- a/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/Deploy.fxml
@@ -4,60 +4,67 @@
 
 <?import edu.wpi.grip.ui.util.DPIUtility?>
 <?import javafx.beans.property.SimpleBooleanProperty?>
+<?import javafx.beans.property.SimpleStringProperty?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
 <VBox styleClass="deploy-pane" maxWidth="Infinity" xmlns:fx="http://javafx.com/fxml/1"
       onKeyPressed="if (event.code == javafx.scene.input.KeyCode.ENTER) { controller.onDeploy() }"
-      xmlns="http://javafx.com/javafx/null" fx:controller="edu.wpi.grip.ui.DeployController">
+      xmlns="http://javafx.com/javafx/null" fx:controller="edu.wpi.grip.ui.DeployController" fillWidth="true">
     <fx:define>
         <SimpleBooleanProperty fx:id="deploying"/>
+        <SimpleStringProperty fx:id="command"/>
     </fx:define>
 
-    <GridPane maxHeight="Infinity">
-        <columnConstraints>
-            <ColumnConstraints hgrow="NEVER" halignment="RIGHT"/>
-            <ColumnConstraints hgrow="ALWAYS"/>
-            <ColumnConstraints hgrow="NEVER">
-                <prefWidth>
-                    <DPIUtility fx:constant="FONT_SIZE"/>
-                </prefWidth>
-            </ColumnConstraints>
-            <ColumnConstraints hgrow="NEVER" halignment="RIGHT"/>
-            <ColumnConstraints hgrow="ALWAYS"/>
-        </columnConstraints>
+    <HBox maxWidth="Infinity">
+        <GridPane maxHeight="Infinity" HBox.hgrow="ALWAYS">
+            <columnConstraints>
+                <ColumnConstraints hgrow="NEVER" halignment="RIGHT"/>
+                <ColumnConstraints hgrow="ALWAYS"/>
+            </columnConstraints>
 
-        <Label disable="${deployButton.disabled}" text="Address" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
-        <TextField disable="${deployButton.disabled}" fx:id="address" promptText="Address" GridPane.columnIndex="1"
+            <Label disable="${deployButton.disabled}" text="Address" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
+            <TextField disable="${deployButton.disabled}" fx:id="address" promptText="Address" GridPane.columnIndex="1"
+                       GridPane.rowIndex="0"/>
+
+            <Label disable="${deployButton.disabled}" text="User" GridPane.columnIndex="0" GridPane.rowIndex="1"/>
+            <TextField disable="${deployButton.disabled}" fx:id="user" promptText="Username" GridPane.columnIndex="1"
+                       GridPane.rowIndex="1"/>
+
+            <Label disable="${deployButton.disabled}" text="Password" GridPane.columnIndex="0" GridPane.rowIndex="2"/>
+            <PasswordField disable="${deployButton.disabled}" fx:id="password" promptText="Password"
+                           GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+
+        </GridPane>
+        <Separator orientation="VERTICAL" HBox.hgrow="NEVER" visible="false">
+            <prefWidth>
+                <DPIUtility fx:constant="SMALL_ICON_SIZE"/>
+            </prefWidth>
+        </Separator>
+        <GridPane maxHeight="Infinity" HBox.hgrow="ALWAYS">
+            <columnConstraints>
+                <ColumnConstraints hgrow="NEVER" halignment="RIGHT"/>
+                <ColumnConstraints hgrow="ALWAYS"/>
+            </columnConstraints>
+
+            <Label disable="${deployButton.disabled}" text="Deploy Directory" GridPane.columnIndex="0"
                    GridPane.rowIndex="0"/>
+            <TextField disable="${deployButton.disabled}" fx:id="deployDir" promptText="Deploy Directory"
+                       GridPane.columnIndex="1" GridPane.rowIndex="0"/>
 
-        <Label disable="${deployButton.disabled}" text="User" GridPane.columnIndex="0" GridPane.rowIndex="1"/>
-        <TextField disable="${deployButton.disabled}" fx:id="user" promptText="Username" GridPane.columnIndex="1"
-                   GridPane.rowIndex="1"/>
+            <Label disable="${deployButton.disabled}" text="Java Home" GridPane.columnIndex="0" GridPane.rowIndex="1"/>
+            <TextField disable="${deployButton.disabled}" fx:id="javaHome" promptText="Java Home"
+                       GridPane.columnIndex="1" GridPane.rowIndex="1"/>
 
-        <Label disable="${deployButton.disabled}" text="Password" GridPane.columnIndex="0" GridPane.rowIndex="2"/>
-        <PasswordField disable="${deployButton.disabled}" fx:id="password" promptText="Password"
+            <Label disable="${deployButton.disabled}" text="JVM Arguments" GridPane.columnIndex="0"
+                   GridPane.rowIndex="2"/>
+            <TextField disable="${deployButton.disabled}" fx:id="jvmArgs" promptText="JVM Arguments"
                        GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+        </GridPane>
+    </HBox>
 
-        <Label disable="${deployButton.disabled}" text="Deploy Directory" GridPane.columnIndex="3"
-               GridPane.rowIndex="0"/>
-        <TextField disable="${deployButton.disabled}" fx:id="deployDir" promptText="Deploy Directory"
-                   GridPane.columnIndex="4" GridPane.rowIndex="0"/>
-
-        <Label disable="${deployButton.disabled}" text="Java Home" GridPane.columnIndex="3" GridPane.rowIndex="1"/>
-        <TextField disable="${deployButton.disabled}" fx:id="javaHome" promptText="Java Home"
-                   GridPane.columnIndex="4" GridPane.rowIndex="1"/>
-
-        <Label disable="${deployButton.disabled}" text="JVM Arguments" GridPane.columnIndex="3" GridPane.rowIndex="2"/>
-        <TextField disable="${deployButton.disabled}" fx:id="jvmArgs" promptText="JVM Arguments"
-                   GridPane.columnIndex="4" GridPane.rowIndex="2"/>
-
-        <Label disable="${deployButton.disabled}" text="Command" GridPane.columnIndex="0" GridPane.rowIndex="3"/>
-        <Label fx:id="command" disable="${deployButton.disabled}" GridPane.columnIndex="1" GridPane.columnSpan="4"
-               GridPane.rowIndex="3" style="-fx-font-family: monospace"/>
-    </GridPane>
-
+    <Separator orientation="HORIZONTAL" VBox.vgrow="NEVER"/>
 
     <ButtonBar>
         <buttons>
@@ -89,5 +96,6 @@
         <Label fx:id="status"/>
     </StackPane>
 
-    <TextArea fx:id="console" editable="false" styleClass="console" prefRowCount="24" prefColumnCount="100"/>
+    <TextArea fx:id="console" editable="false" styleClass="console" prefRowCount="24" prefColumnCount="100"
+              VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/ui/src/main/resources/edu/wpi/grip/ui/GRIP.css
+++ b/ui/src/main/resources/edu/wpi/grip/ui/GRIP.css
@@ -189,7 +189,7 @@ VBox.sockets {
     -fx-background-color: grey;
 }
 
-.property-sheet .property-pane, .deploy-pane GridPane {
+.property-sheet .property-pane {
     -fx-hgap: 4em;
     -fx-vgap: 1em;
     -fx-padding: 0;
@@ -205,6 +205,12 @@ VBox.sockets {
 
 .deploy-pane {
     -fx-spacing: 1em;
+}
+
+.deploy-pane GridPane {
+    -fx-hgap: 1em;
+    -fx-vgap: 1em;
+    -fx-padding: 0;
 }
 
 .deploy-pane StackPane {


### PR DESCRIPTION
JVM arguments can be specified, and some reasonable defaults are included for new projects (and old projects created before this change).  These settings should help reduce OOM errors, and help us debug new ones.

Running from a robot program is now also easier, since a new wrapper script is included to facilitate the JVM options.

```c++
void RobotInit() override {
    system("/home/lvuser/grip &");
}
```

In addition, the resulting file name of the deployed project can be changed from the default of "project.grip".  This lets you upload multiple versions to the roboRIO, and then the robot code can select one of them at the start of a match, although the robot code to run the project might be a little more complicated in this case.

We also now check the MD5 sum of the JAR before deploying it.  If it matches the JAR we're about to upload, we just skip it.  This makes deploys after the first one a LOT faster.

And other mostly cosmetic deploying changes, including:

* A two-column layout
* Pressing "enter" anywhere in the dialog makes the deploy start
* The command that will run on the roboRIO is shown in the dialog

Closes #425 