### PR TITLE
Enable non-git builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ def getVersionName = { ->
         }
         return stdout.toString().trim().substring(1)
     } catch (org.gradle.process.internal.ExecException e) {
+        if (!new File(rootDir, '.git/HEAD').exists()) {
+            println("WARN: Could not fetch Git Tag for build version. No Git HEAD available. Substituting version 0.0.0")
+            return "0.0.0"
+        }
         println("WARN: Could not fetch Git Tag for build version. Please install Git and add it to your PATH. For now, the Git commit hash has been substituted.")
         return getGitCommit()
     }
@@ -50,6 +54,10 @@ def getVersionSimple = { ->
         }
         return stdout.toString().trim().substring(1)
     } catch (org.gradle.process.internal.ExecException e) {
+        if (!new File(rootDir, '.git/HEAD').exists()) {
+            println("WARN: Could not fetch Git Tag for build version. No Git HEAD available. Substituting version 0.0.0")
+            return "0.0.0"
+        }
         println("WARN: Could not fetch Git Tag for build version. Please install Git and add it to your PATH. For now, the Git commit hash has been substituted.")
         return getGitCommit()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,26 +16,42 @@ plugins {
 apply plugin: 'nebula-aggregate-javadocs'
 
 
+def getGitCommit = { ->
+    String HEAD_REF = new File(rootDir, '.git/HEAD').text.replace("ref: ", "").replace("\n", "")
+    String COMMIT_HASH = new File(rootDir, ".git/${HEAD_REF}").text.substring(0, 7)
+    return COMMIT_HASH
+}
+
 /*
  * Gets the version name from the latest Git tag
  * http://ryanharter.com/blog/2013/07/30/automatic-versioning-with-git-and-gradle/
  */
 def getVersionName = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim().substring(1)
+    } catch (org.gradle.process.internal.ExecException e) {
+        println("WARN: Could not fetch Git Tag for build version. Please install Git and add it to your PATH. For now, the Git commit hash has been substituted.")
+        return getGitCommit()
     }
-    return stdout.toString().trim().substring(1)
 }
 
 def getVersionSimple = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags', '--abbrev=0'
-        standardOutput = stdout
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'describe', '--tags', '--abbrev=0'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim().substring(1)
+    } catch (org.gradle.process.internal.ExecException e) {
+        println("WARN: Could not fetch Git Tag for build version. Please install Git and add it to your PATH. For now, the Git commit hash has been substituted.")
+        return getGitCommit()
     }
-    return stdout.toString().trim().substring(1)
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ plugins {
 }
 apply plugin: 'nebula-aggregate-javadocs'
 
-
 def getGitCommit = { ->
     String HEAD_REF = new File(rootDir, '.git/HEAD').text.replace("ref: ", "").replace("\n", "")
     String COMMIT_HASH = new File(rootDir, ".git/${HEAD_REF}").text.substring(0, 7)
@@ -27,6 +26,7 @@ def getGitCommit = { ->
  * http://ryanharter.com/blog/2013/07/30/automatic-versioning-with-git-and-gradle/
  */
 def getVersionName = { ->
+    if (project.hasProperty("vers")) return vers
     try {
         def stdout = new ByteArrayOutputStream()
         exec {
@@ -41,6 +41,7 @@ def getVersionName = { ->
 }
 
 def getVersionSimple = { ->
+    if (project.hasProperty("vers")) return vers
     try {
         def stdout = new ByteArrayOutputStream()
         exec {


### PR DESCRIPTION
Upon merging this will resolve #461 

For users without Git on their PATH, build versions will default to the current HEAD Commit Tag read manually. Alternatively, users may also specify the 'vers' property (via `./gradlew task -Pvers=myversion`) if they want to tag the build with a specified version.

For users with Git on their PATH, the behavior of grabbing the current Tag remains unchanged.