### PR TITLE
Fix deserializing ProjectSettings from previous GRIP versions

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/serialization/Project.java
+++ b/core/src/main/java/edu/wpi/grip/core/serialization/Project.java
@@ -2,6 +2,7 @@ package edu.wpi.grip.core.serialization;
 
 import com.google.common.eventbus.EventBus;
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 import edu.wpi.grip.core.*;
 import edu.wpi.grip.core.sources.CameraSource;
 import edu.wpi.grip.core.sources.ImageFileSource;
@@ -22,10 +23,8 @@ public class Project {
     private EventBus eventBus;
     @Inject
     private Pipeline pipeline;
-    @Inject
-    private Palette palette;
 
-    protected final XStream xstream = new XStream();
+    protected final XStream xstream = new XStream(new PureJavaReflectionProvider());
     private Optional<File> file = Optional.empty();
 
     @Inject

--- a/core/src/test/java/edu/wpi/grip/core/serialization/ProjectTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/serialization/ProjectTest.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.assertEquals;
 import static org.bytedeco.javacpp.opencv_core.*;
 
@@ -142,7 +143,7 @@ public class ProjectTest {
         serializeAndDeserialize();
 
 
-        final Step fromPipeline =  pipeline.getSteps().get(0);
+        final Step fromPipeline = pipeline.getSteps().get(0);
         InputSocket<Number> a = (InputSocket<Number>) fromPipeline.getInputSockets()[0];
         InputSocket<Number> b = (InputSocket<Number>) fromPipeline.getInputSockets()[1];
         OutputSocket<Number> sum = (OutputSocket<Number>) fromPipeline.getOutputSockets()[0];
@@ -161,7 +162,7 @@ public class ProjectTest {
         pipeline.addStep(stepFactory.create(pythonAdditionOperationFromURL));
         serializeAndDeserialize();
 
-        final Step fromPipeline =  pipeline.getSteps().get(0);
+        final Step fromPipeline = pipeline.getSteps().get(0);
         InputSocket<Number> a = (InputSocket<Number>) fromPipeline.getInputSockets()[0];
         InputSocket<Number> b = (InputSocket<Number>) fromPipeline.getInputSockets()[1];
         OutputSocket<Number> sum = (OutputSocket<Number>) fromPipeline.getOutputSockets()[0];
@@ -181,7 +182,7 @@ public class ProjectTest {
         pipeline.addStep(stepFactory.create(pythonAdditionOperationFromSource));
         serializeAndDeserialize();
 
-        final Step fromPipeline =  pipeline.getSteps().get(0);
+        final Step fromPipeline = pipeline.getSteps().get(0);
         InputSocket<Number> a = (InputSocket<Number>) fromPipeline.getInputSockets()[0];
         InputSocket<Number> b = (InputSocket<Number>) fromPipeline.getInputSockets()[1];
         OutputSocket<Number> sum = (OutputSocket<Number>) fromPipeline.getOutputSockets()[0];
@@ -218,7 +219,6 @@ public class ProjectTest {
         OutputSocket<Number> sum2 = (OutputSocket<Number>) step2Out.getOutputSockets()[0];
 
 
-
         a1.setValue(123);
         b1.setValue(456);
         b2.setValue(789);
@@ -238,7 +238,6 @@ public class ProjectTest {
         InputSocket<Mat> a = (InputSocket<Mat>) step1.getInputSockets()[0];
         InputSocket<Mat> b = (InputSocket<Mat>) step1.getInputSockets()[1];
         OutputSocket<Mat> sum = (OutputSocket<Mat>) step1.getOutputSockets()[0];
-
 
 
         a.setValue(new Mat(1, 1, CV_32F, new Scalar(1234.5)));
@@ -279,5 +278,19 @@ public class ProjectTest {
                 190, pipeline.getProjectSettings().getTeamNumber());
         assertEquals("Deploy address was not serialized/deserialized",
                 "roborio-191-frc.local", pipeline.getProjectSettings().getDeployAddress());
+    }
+
+    @Test
+    public void testUnspecifiedProjectSettings() {
+        Reader reader = new StringReader("<grip:Pipeline>" +
+                "  <sources/>" +
+                "  <steps/>" +
+                "  <connections/>" +
+                "  <settings/>" +
+                "</grip:Pipeline>");
+
+        project.open(reader);
+
+        assertNotNull("Project setting was null", pipeline.getProjectSettings().getDeployJvmOptions());
     }
 }


### PR DESCRIPTION
When opening projects with missing settings, we should use the default
values for those settings.  By default, XStream sets them to null, but
we can override that using `PureJavaReflectionProvider`.

Closes #491