### PR TITLE
Revert "Adds a 32 bit windows release"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,6 @@ test_script:
 
 platform:
   - x64
-  - x86
-
-matrix:
-  fast_finish: true # set this flag to immediately finish build once one of the jobs fails.
 
 artifacts:
   - path: ui\build\distributions\*.exe


### PR DESCRIPTION
Reverts WPIRoboticsProjects/GRIP#452

This isn't really a 32 bit build like we originally expected.