### PR TITLE
Start and stop headless GRIP using NetworkTables

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/GRIPCoreModule.java
+++ b/core/src/main/java/edu/wpi/grip/core/GRIPCoreModule.java
@@ -10,11 +10,13 @@ import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
 import edu.wpi.grip.core.events.UnexpectedThrowableEvent;
+import edu.wpi.grip.core.operations.networktables.NTManager;
 import edu.wpi.grip.core.serialization.Project;
 import edu.wpi.grip.core.sources.CameraSource;
 import edu.wpi.grip.core.sources.ImageFileSource;
 import edu.wpi.grip.core.sources.MultiImageFileSource;
 import edu.wpi.grip.core.util.ExceptionWitness;
+import edu.wpi.grip.core.util.GRIPMode;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -87,6 +89,8 @@ public class GRIPCoreModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(GRIPMode.class).toInstance(GRIPMode.HEADLESS);
+
         // Register any injected object on the event bus
         bindListener(Matchers.any(), new TypeListener() {
             @Override
@@ -96,6 +100,8 @@ public class GRIPCoreModule extends AbstractModule {
         });
 
         bind(EventBus.class).toInstance(eventBus);
+
+        bind(NTManager.class).asEagerSingleton();
 
         install(new FactoryModuleBuilder().build(new TypeLiteral<Connection.Factory<Object>>() {
         }));

--- a/core/src/main/java/edu/wpi/grip/core/Pipeline.java
+++ b/core/src/main/java/edu/wpi/grip/core/Pipeline.java
@@ -7,7 +7,6 @@ import com.google.inject.Singleton;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import edu.wpi.grip.core.events.*;
-import edu.wpi.grip.core.operations.networktables.NTManager;
 import edu.wpi.grip.core.settings.ProjectSettings;
 
 import javax.inject.Inject;
@@ -36,10 +35,6 @@ public class Pipeline {
     @Inject
     @XStreamOmitField
     private EventBus eventBus;
-
-    @Inject
-    @XStreamOmitField
-    private NTManager ntManager;
 
     /*
      * We have separate locks for sources and steps because we don't want to

--- a/core/src/main/java/edu/wpi/grip/core/operations/networktables/NTManager.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/networktables/NTManager.java
@@ -5,9 +5,11 @@ import com.google.inject.Singleton;
 import edu.wpi.first.wpilibj.networktables.NetworkTable;
 import edu.wpi.first.wpilibj.networktables.NetworkTablesJNI;
 import edu.wpi.grip.core.Pipeline;
+import edu.wpi.grip.core.PipelineRunner;
 import edu.wpi.grip.core.events.ProjectSettingsChangedEvent;
 import edu.wpi.grip.core.events.StepRemovedEvent;
 import edu.wpi.grip.core.settings.ProjectSettings;
+import edu.wpi.grip.core.util.GRIPMode;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -41,13 +43,16 @@ public class NTManager {
         put(6, Level.FINEST);
     }};
 
-    @Inject Pipeline pipeline;
+    @Inject private Pipeline pipeline;
+    @Inject private PipelineRunner pipelineRunner;
+    @Inject private GRIPMode gripMode;
 
     @Inject
     public NTManager(Logger logger) {
         checkNotNull(logger, "Logger cannot be null");
         // We may have another instance of this method lying around
         NetworkTable.shutdown();
+
         // Redirect NetworkTables log messages to our own log files.  This gets rid of console spam, and it also lets
         // us grep through NetworkTables messages just like any other messages.
         NetworkTablesJNI.setLogger((level, file, line, msg) -> {
@@ -56,6 +61,30 @@ public class NTManager {
         }, 0);
 
         NetworkTable.setClientMode();
+
+        // When in headless mode, start and stop the pipeline based on the "GRIP/run" key.  This allows robot programs
+        // to control GRIP without actually restarting the process.
+        NetworkTable.getTable("GRIP").addTableListener("run", (source, key, value, isNew) -> {
+            if (gripMode == GRIPMode.HEADLESS) {
+                if (!(value instanceof Boolean)) {
+                    logger.warning("NetworkTables value GRIP/run should be a boolean!");
+                    return;
+                }
+
+                if ((Boolean) value) {
+                    if (!pipelineRunner.isRunning()) {
+                        logger.info("Starting GRIP from NetworkTables");
+                        pipelineRunner.startAsync();
+                    }
+                } else if (pipelineRunner.isRunning()) {
+                    logger.info("Stopping GRIP from NetworkTables");
+                    pipelineRunner.stopAsync();
+
+                }
+            }
+        }, true);
+
+        NetworkTable.shutdown();
     }
 
     /**

--- a/core/src/main/java/edu/wpi/grip/core/util/GRIPMode.java
+++ b/core/src/main/java/edu/wpi/grip/core/util/GRIPMode.java
@@ -1,0 +1,10 @@
+package edu.wpi.grip.core.util;
+
+/**
+ * An enum that indicates if GRIP is running in GUI mode with JavaFX or as a headless command line application.
+ * <p>
+ * To the get the mode, this can be injected into a class (ie: @Inject private GRIPMode mode;)
+ */
+public enum GRIPMode {
+    GUI, HEADLESS
+}

--- a/ui/src/main/java/edu/wpi/grip/ui/GRIPUIModule.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/GRIPUIModule.java
@@ -8,6 +8,7 @@ import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
 import edu.wpi.grip.core.Source;
+import edu.wpi.grip.core.util.GRIPMode;
 import edu.wpi.grip.ui.annotations.ParametrizedController;
 import edu.wpi.grip.ui.components.ExceptionWitnessResponderButton;
 import edu.wpi.grip.ui.components.StartStoppableButton;
@@ -28,6 +29,7 @@ import java.io.IOException;
 public class GRIPUIModule extends AbstractModule {
     @Override
     protected void configure() {
+        bind(GRIPMode.class).toInstance(GRIPMode.GUI);
 
         bindListener(Matchers.any(), new TypeListener() {
             @Override

--- a/ui/src/test/java/edu/wpi/grip/ui/pipeline/PipelineUITest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/pipeline/PipelineUITest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.util.Modules;
 import edu.wpi.grip.core.*;
 import edu.wpi.grip.core.util.MockExceptionWitness;
 import edu.wpi.grip.ui.GRIPUIModule;
@@ -44,7 +45,7 @@ public class PipelineUITest extends ApplicationTest {
     public void start(Stage stage) {
         testModule = new GRIPCoreTestModule();
         testModule.setUp();
-        final Injector injector = Guice.createInjector(testModule, new GRIPUIModule());
+        final Injector injector = Guice.createInjector(Modules.override(testModule).with(new GRIPUIModule()));
         eventBus = injector.getInstance(EventBus.class);
         pipeline = injector.getInstance(Pipeline.class);
         additionOperation = new AdditionOperation();

--- a/ui/src/test/java/edu/wpi/grip/ui/pipeline/input/InputSocketControllerFactoryTest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/pipeline/input/InputSocketControllerFactoryTest.java
@@ -3,6 +3,7 @@ package edu.wpi.grip.ui.pipeline.input;
 import com.google.common.eventbus.EventBus;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.util.Modules;
 import edu.wpi.grip.core.InputSocket;
 import edu.wpi.grip.core.Operation;
 import edu.wpi.grip.core.Palette;
@@ -77,7 +78,7 @@ public class InputSocketControllerFactoryTest extends ApplicationTest {
     public void start(Stage stage) {
         testModule = new GRIPCoreTestModule();
         testModule.setUp();
-        Injector injector = Guice.createInjector(testModule, new GRIPUIModule());
+        Injector injector = Guice.createInjector(Modules.override(testModule).with(new GRIPUIModule()));
         inputSocketControllerFactory = injector.getInstance(InputSocketControllerFactory.class);
         stepFactory = injector.getInstance(Step.Factory.class);
         gridPane = new GridPane();


### PR DESCRIPTION
This lets robot programs start and stop GRIP to save CPU without having
to wait for the process to start up again.

For example,

```java
NetworkTable table = NetworkTable.getTable("GRIP");

table.putBoolean("run", false); // Stop GRIP without killing the process

doSomeStuffThatDoesntNeedVision();

table.putBoolean("run", true); // Start GRIP again
```

This should be useful for teams that want to do auto alignment in teleop, since they could start and stop vision processing whenever the driver presses the button to auto aim.

Closes #501