### PR TITLE
Fixes Null Pointer from ExceptionWitnessResponderButton

### DIFF
--- a/ui/src/main/java/edu/wpi/grip/ui/components/ExceptionWitnessResponderButton.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/components/ExceptionWitnessResponderButton.java
@@ -160,6 +160,8 @@ public final class ExceptionWitnessResponderButton extends Button {
             final ExceptionPopOver newPopOver = new ExceptionPopOver(this.popOverTitle);
             // Scene and root are null when the the constructor is called
             // They are not null once they are added to a scene.
+            assert getScene() != null : "Scene should not be null, this object has not been added to the scene yet";
+            assert getScene().getRoot() != null : "Root should not be null, this object has not been added to the scene yet";
             final Parent root = getScene().getRoot();
             newPopOver.getRoot().getStylesheets().addAll(root.getStylesheets());
             newPopOver.getRoot().setStyle(root.getStyle());
@@ -170,6 +172,10 @@ public final class ExceptionWitnessResponderButton extends Button {
 
     @Subscribe
     public void onExceptionEvent(ExceptionEvent event) {
+        if (getScene() == null || getScene().getRoot() == null) {
+            // We are responding to an event prior to this button being added to the scene. Ignore this for now.
+            return;
+        }
         if (event.getOrigin().equals(origin)) {
             // Not timing sensitive. Can remain Platform.runLater
             Platform.runLater(() -> {
@@ -184,6 +190,10 @@ public final class ExceptionWitnessResponderButton extends Button {
 
     @Subscribe
     public void onExceptionClearedEvent(ExceptionClearedEvent event) {
+        if (getScene() == null || getScene().getRoot() == null) {
+            // We are responding to an event prior to this button being added to the scene. Ignore this for now.
+            return;
+        }
         if (event.getOrigin().equals(origin)) {
             // Not timing sensitive. Can remain Platform.runLater
             Platform.runLater(() -> {

--- a/ui/src/test/java/edu/wpi/grip/ui/components/ExceptionWitnessResponderButtonTest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/components/ExceptionWitnessResponderButtonTest.java
@@ -79,7 +79,19 @@ public class ExceptionWitnessResponderButtonTest extends ApplicationTest {
 
     private void flagWarning() {
         witness.flagWarning("A warning without a stacktrace");
+    }
 
+    @Test
+    public void testNoNullPointerBeforeAddedToScene() {
+        final EventBus eventBus = new EventBus();
+        final Object witnessed = new Object();
+        final ExceptionWitness witness = new MockExceptionWitness(eventBus, witnessed);
+
+        final ExceptionWitnessResponderButton button = new ExceptionWitnessResponderButton(witnessed, "Test Button Popover");
+        eventBus.register(button);
+        witness.flagWarning("Warning message");
+        witness.clearException();
+        // We should not get a null pointer because of any of this
     }
 
 }


### PR DESCRIPTION
The button was responding to events before being added to the scene thus
causing a null pointer exception.

Closes #539