### PR TITLE
Moves type resolution in Operations to SocketHint

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/BlurOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/BlurOperation.java
@@ -1,11 +1,8 @@
 package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
-import edu.wpi.grip.core.*;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.Operation;
+import edu.wpi.grip.core.sockets.*;
 
 import java.io.InputStream;
 import java.util.Optional;
@@ -77,14 +74,13 @@ public class BlurOperation implements Operation {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat input = ((InputSocket<Mat>) inputs[0]).getValue().get();
-        final Type type = ((InputSocket<Type>) inputs[1]).getValue().get();
-        final Number radius = ((InputSocket<Number>) inputs[2]).getValue().get();
+        final Mat input = inputHint.retrieveValue(inputs[0]);
+        final Type type = typeHint.retrieveValue(inputs[1]);
+        final Number radius = radiusHint.retrieveValue(inputs[2]);
 
-        final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
-        final Mat output = outputSocket.getValue().get();
+        final Socket<Mat> outputSocket = outputHint.safeCastSocket(outputs[0]);
+        final Mat output = outputHint.retrieveValue(outputSocket);
 
         int kernelSize;
 

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/ConvexHullsOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/ConvexHullsOperation.java
@@ -4,6 +4,7 @@ import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.sockets.InputSocket;
 import edu.wpi.grip.core.Operation;
 import edu.wpi.grip.core.sockets.OutputSocket;
+import edu.wpi.grip.core.sockets.Socket;
 import edu.wpi.grip.core.sockets.SocketHint;
 
 import java.io.InputStream;
@@ -52,19 +53,17 @@ public class ConvexHullsOperation implements Operation {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final InputSocket<ContoursReport> inputSocket = (InputSocket<ContoursReport>) inputs[0];
-
-        final MatVector inputContours = inputSocket.getValue().get().getContours();
+        final Socket<ContoursReport> inputSocket = contoursHint.safeCastSocket(inputs[0]);
+        final ContoursReport inputValue = contoursHint.retrieveValue(inputSocket);
+        final MatVector inputContours = inputValue.getContours();
         final MatVector outputContours = new MatVector(inputContours.size());
 
         for (int i = 0; i < inputContours.size(); i++) {
             convexHull(inputContours.get(i), outputContours.get(i));
         }
 
-        final OutputSocket<ContoursReport> outputSocket = (OutputSocket<ContoursReport>) outputs[0];
-        outputSocket.setValue(new ContoursReport(outputContours,
-                inputSocket.getValue().get().getRows(), inputSocket.getValue().get().getCols()));
+        final Socket<ContoursReport> outputSocket = contoursHint.safeCastSocket(outputs[0]);
+        outputSocket.setValue(new ContoursReport(outputContours, inputValue.getRows(), inputValue.getCols()));
     }
 }

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/DesaturateOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/DesaturateOperation.java
@@ -2,10 +2,7 @@ package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.*;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 
 import java.io.InputStream;
 import java.util.Optional;
@@ -52,12 +49,11 @@ public class DesaturateOperation implements Operation {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat input = ((InputSocket<Mat>) inputs[0]).getValue().get();
+        final Mat input = inputHint.retrieveValue(inputs[0]);
 
-        final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
-        Mat output = outputSocket.getValue().get();
+        final Socket<Mat> outputSocket = outputHint.safeCastSocket(outputs[0]);
+        final Mat output = outputHint.retrieveValue(outputSocket);
 
 
         switch (input.channels()) {

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/DistanceTransformOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/DistanceTransformOperation.java
@@ -2,18 +2,14 @@
 package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
-
-import edu.wpi.grip.core.sockets.InputSocket;
 import edu.wpi.grip.core.Operation;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
+import org.bytedeco.javacpp.opencv_core.Mat;
 
 import java.io.InputStream;
 import java.util.Optional;
 
-import org.bytedeco.javacpp.opencv_core.Mat;
-import static org.bytedeco.javacpp.opencv_core.*;
+import static org.bytedeco.javacpp.opencv_core.CV_8U;
 import static org.bytedeco.javacpp.opencv_imgproc.*;
 
 /**
@@ -107,17 +103,17 @@ public class DistanceTransformOperation implements Operation {
 
     @Override
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat input = (Mat) inputs[0].getValue().get();
+        final Mat input = srcHint.retrieveValue(inputs[0]);
 
         if (input.type() != CV_8U) {
             throw new IllegalArgumentException("Distance transform only works on 8-bit binary images");
         }
 
-        final Type type = (Type) inputs[1].getValue().get();
-        final MaskSize maskSize = (MaskSize) inputs[2].getValue().get();
+        final Type type = typeHint.retrieveValue(inputs[1]);
+        final MaskSize maskSize = maskSizeHint.retrieveValue(inputs[2]);
 
-        final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
-        final Mat output = outputSocket.getValue().get();
+        final Socket<Mat> outputSocket = outputHint.safeCastSocket(outputs[0]);
+        final Mat output = outputHint.retrieveValue(outputSocket);
 
         distanceTransform(input, output, type.value, maskSize.value);
         output.convertTo(output, CV_8U);

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/FilterLinesOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/FilterLinesOperation.java
@@ -2,10 +2,7 @@ package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.*;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 
 import java.io.InputStream;
 import java.util.List;
@@ -22,7 +19,7 @@ public class FilterLinesOperation implements Operation {
 
     private final SocketHint<Number> minLengthHint = SocketHints.Inputs.createNumberSpinnerSocketHint("Min Length", 20);
 
-    private final SocketHint<List> angleHint = SocketHints.Inputs.createNumberListRangeSocketHint("Angle", 0, 360);
+    private final SocketHint<List<Number>> angleHint = SocketHints.Inputs.createNumberListRangeSocketHint("Angle", 0, 360);
 
     private final SocketHint<LinesReport> outputHint =
             new SocketHint.Builder<>(LinesReport.class)
@@ -63,16 +60,15 @@ public class FilterLinesOperation implements Operation {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final LinesReport inputLines = (LinesReport) inputs[0].getValue().get();
-        final double minLengthSquared = Math.pow(((Number) inputs[1].getValue().get()).doubleValue(), 2);
-        final double minAngle = ((InputSocket<List<Number>>) inputs[2]).getValue().get().get(0).doubleValue();
-        final double maxAngle = ((InputSocket<List<Number>>) inputs[2]).getValue().get().get(1).doubleValue();
+        final LinesReport inputLines = inputHint.retrieveValue(inputs[0]);
+        final double minLengthSquared = Math.pow(minLengthHint.retrieveValue(inputs[1]).doubleValue(), 2);
+        final double minAngle = angleHint.retrieveValue(inputs[2]).get(0).doubleValue();
+        final double maxAngle = angleHint.retrieveValue(inputs[2]).get(1).doubleValue();
 
-        final OutputSocket<LinesReport> linesOutputSocket = (OutputSocket<LinesReport>) outputs[0];
+        final Socket<LinesReport> linesOutputSocket = outputHint.safeCastSocket(outputs[0]);
 
-        List<LinesReport.Line> lines = inputLines.getLines().stream()
+        final List<LinesReport.Line> lines = inputLines.getLines().stream()
                 .filter(line -> line.lengthSquared() >= minLengthSquared)
                 .filter(line -> (line.angle() >= minAngle && line.angle() <= maxAngle)
                         || (line.angle() + 180.0 >= minAngle && line.angle() + 180.0 <= maxAngle))

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/FindBlobsOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/FindBlobsOperation.java
@@ -22,10 +22,10 @@ public class FindBlobsOperation implements Operation {
 
     private final SocketHint<Mat> inputHint = SocketHints.Inputs.createMatSocketHint("Input", false);
     private final SocketHint<Number> minAreaHint = SocketHints.Inputs.createNumberSpinnerSocketHint("Min Area", 1);
-    private final SocketHint<List> circularityHint = SocketHints.Inputs.createNumberListRangeSocketHint("Circularity", 0.0, 1.0);
+    private final SocketHint<List<Number>> circularityHint = SocketHints.Inputs.createNumberListRangeSocketHint("Circularity", 0.0, 1.0);
     private final SocketHint<Boolean> colorHint = SocketHints.createBooleanSocketHint("Dark Blobs", false);
 
-    private final SocketHint<BlobsReport> blobsHint = new SocketHint.Builder(BlobsReport.class)
+    private final SocketHint<BlobsReport> blobsHint = new SocketHint.Builder<>(BlobsReport.class)
             .identifier("Blobs")
             .initialValueSupplier(BlobsReport::new)
             .build();
@@ -68,10 +68,10 @@ public class FindBlobsOperation implements Operation {
     @Override
     @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat input = (Mat) inputs[0].getValue().get();
-        final Number minArea = (Number) inputs[1].getValue().get();
-        final List<Number> circularity = (List<Number>) inputs[2].getValue().get();
-        final Boolean darkBlobs = (Boolean) inputs[3].getValue().get();
+        final Mat input = inputHint.retrieveValue(inputs[0]);
+        final Number minArea = minAreaHint.retrieveValue(inputs[1]);
+        final List<Number> circularity = circularityHint.retrieveValue(inputs[2]);
+        final Boolean darkBlobs = colorHint.retrieveValue(inputs[3]);
 
 
         final SimpleBlobDetector blobDetector = SimpleBlobDetector.create(new SimpleBlobDetector.Params()
@@ -96,6 +96,6 @@ public class FindBlobsOperation implements Operation {
             blobs.add(new BlobsReport.Blob(keyPoint.pt().x(), keyPoint.pt().y(), keyPoint.size()));
         }
 
-        ((OutputSocket<BlobsReport>) outputs[0]).setValue(new BlobsReport(input, blobs));
+        blobsHint.safeCastSocket(outputs[0]).setValue(new BlobsReport(input, blobs));
     }
 }

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/FindContoursOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/FindContoursOperation.java
@@ -2,10 +2,7 @@ package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.*;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 
 import java.io.InputStream;
 import java.util.Optional;
@@ -68,9 +65,9 @@ public class FindContoursOperation implements Operation {
     @Override
     @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs, Optional<?> data) {
-        final Mat input = ((InputSocket<Mat>) inputs[0]).getValue().get();
+        final Mat input = inputHint.retrieveValue(inputs[0]);
         final Mat tmp = ((Optional<Mat>) data).get();
-        final boolean externalOnly = ((InputSocket<Boolean>) inputs[1]).getValue().get();
+        final boolean externalOnly = externalHint.retrieveValue(inputs[1]);
 
         if (input.empty()) {
             return;
@@ -86,7 +83,7 @@ public class FindContoursOperation implements Operation {
         findContours(tmp, contours, externalOnly ? CV_RETR_EXTERNAL : CV_RETR_LIST,
                 CV_CHAIN_APPROX_TC89_KCOS);
 
-        final OutputSocket<ContoursReport> contoursSocket = (OutputSocket<ContoursReport>) outputs[0];
+        final Socket<ContoursReport> contoursSocket = contoursHint.safeCastSocket(outputs[0]);
         contoursSocket.setValue(new ContoursReport(contours, input.rows(), input.cols()));
     }
 }

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/FindLinesOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/FindLinesOperation.java
@@ -2,10 +2,7 @@ package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.*;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 import org.bytedeco.javacpp.indexer.FloatIndexer;
 
 import java.io.InputStream;
@@ -63,9 +60,9 @@ public class FindLinesOperation implements Operation {
     @Override
     @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs, Optional<?> data) {
-        final Mat input = (Mat) inputs[0].getValue().get();
-        final OutputSocket<LinesReport> linesReportSocket = (OutputSocket<LinesReport>) outputs[0];
-        final LineSegmentDetector lsd = linesReportSocket.getValue().get().getLineSegmentDetector();
+        final Mat input = inputHint.retrieveValue(inputs[0]);
+        final Socket<LinesReport> linesReportSocket = linesHint.safeCastSocket(outputs[0]);
+        final LineSegmentDetector lsd = linesHint.retrieveValue(linesReportSocket).getLineSegmentDetector();
 
         final Mat lines = new Mat();
         if (input.channels() == 1) {
@@ -79,7 +76,7 @@ public class FindLinesOperation implements Operation {
         }
 
         // Store the lines in the LinesReport object
-        List<LinesReport.Line> lineList = new ArrayList<>();
+        final List<LinesReport.Line> lineList = new ArrayList<>();
         if (!lines.empty()) {
             final FloatIndexer indexer = lines.<FloatIndexer>createIndexer();
             final float[] tmp = new float[4];

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/HSVThresholdOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/HSVThresholdOperation.java
@@ -1,17 +1,12 @@
 package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 import org.bytedeco.javacpp.opencv_core.Mat;
 import org.bytedeco.javacpp.opencv_core.Scalar;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static org.bytedeco.javacpp.opencv_core.inRange;
 import static org.bytedeco.javacpp.opencv_imgproc.COLOR_BGR2HSV;
@@ -21,12 +16,10 @@ import static org.bytedeco.javacpp.opencv_imgproc.cvtColor;
  * An {@link edu.wpi.grip.core.Operation} that converts a color image into a binary image based on the HSV threshold ranges for each channel
  */
 public class HSVThresholdOperation extends ThresholdOperation {
-
-    private static final Logger logger = Logger.getLogger(HSVThresholdOperation.class.getName());
     private final SocketHint<Mat> inputHint = SocketHints.Inputs.createMatSocketHint("Input", false);
-    private final SocketHint<List> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 180.0);
-    private final SocketHint<List> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 255.0);
-    private final SocketHint<List> valueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Value", 0.0, 255.0);
+    private final SocketHint<List<Number>> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 180.0);
+    private final SocketHint<List<Number>> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 255.0);
+    private final SocketHint<List<Number>> valueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Value", 0.0, 255.0);
 
     private final SocketHint<Mat> outputHint = SocketHints.Outputs.createMatSocketHint("Output");
 
@@ -62,17 +55,17 @@ public class HSVThresholdOperation extends ThresholdOperation {
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs, Optional<?> data) {
         final Mat[] dataArray = (Mat[]) data.orElseThrow(() -> new IllegalStateException("Data was not provided"));
 
-        final Mat input = ((InputSocket<Mat>) inputs[0]).getValue().get();
-        final List<Number> channel1 = ((InputSocket<List<Number>>) inputs[1]).getValue().get();
-        final List<Number> channel2 = ((InputSocket<List<Number>>) inputs[2]).getValue().get();
-        final List<Number> channel3 = ((InputSocket<List<Number>>) inputs[3]).getValue().get();
+        final Mat input = inputHint.retrieveValue(inputs[0]);
+        final List<Number> channel1 = hueHint.retrieveValue(inputs[1]);
+        final List<Number> channel2 = saturationHint.retrieveValue(inputs[2]);
+        final List<Number> channel3 = valueHint.retrieveValue(inputs[3]);
 
         if (input.channels() != 3) {
             throw new IllegalArgumentException("HSV Threshold needs a 3-channel input");
         }
 
-        final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
-        final Mat output = outputSocket.getValue().get();
+        final Socket<Mat> outputSocket = outputHint.safeCastSocket(outputs[0]);
+        final Mat output = outputHint.retrieveValue(outputSocket);
 
         final Scalar lowScalar = new Scalar(
                 channel1.get(0).doubleValue(),
@@ -87,12 +80,9 @@ public class HSVThresholdOperation extends ThresholdOperation {
         final Mat high = reallocateMatIfInputSizeOrWidthChanged(dataArray, 1, highScalar, input);
         final Mat hsv = dataArray[2];
 
-        try {
-            cvtColor(input, hsv, COLOR_BGR2HSV);
-            inRange(hsv, low, high, output);
-            outputSocket.setValue(output);
-        } catch (RuntimeException e) {
-            logger.log(Level.WARNING, e.getMessage(), e);
-        }
+
+        cvtColor(input, hsv, COLOR_BGR2HSV);
+        inRange(hsv, low, high, output);
+        outputSocket.setValue(output);
     }
 }

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/MaskOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/MaskOperation.java
@@ -2,10 +2,7 @@ package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
 import edu.wpi.grip.core.*;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 
 import java.io.InputStream;
 import java.util.Optional;
@@ -61,11 +58,11 @@ public class MaskOperation implements Operation {
     @Override
     @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat input = ((InputSocket<Mat>) inputs[0]).getValue().get();
-        final Mat mask = ((InputSocket<Mat>) inputs[1]).getValue().get();
+        final Mat input = inputHint.retrieveValue(inputs[0]);
+        final Mat mask = maskHint.retrieveValue(inputs[1]);
 
-        final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
-        final Mat output = outputSocket.getValue().get();
+        final Socket<Mat> outputSocket = outputHint.safeCastSocket(outputs[0]);
+        final Mat output = outputHint.retrieveValue(outputSocket);
 
         // Clear the output to black, then copy the input to it with the mask
         bitwise_xor(output, output, output);

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/NormalizeOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/NormalizeOperation.java
@@ -3,11 +3,8 @@ package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
 
-import edu.wpi.grip.core.sockets.InputSocket;
+import edu.wpi.grip.core.sockets.*;
 import edu.wpi.grip.core.Operation;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
 
 import java.io.InputStream;
 import java.util.Optional;
@@ -88,13 +85,13 @@ public class NormalizeOperation implements Operation {
 
     @Override
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat input = (Mat) inputs[0].getValue().get();
-        final Type type = (Type) inputs[1].getValue().get();
-        final Number a = (Number) inputs[2].getValue().get();
-        final Number b = (Number) inputs[3].getValue().get();
+        final Mat input = srcHint.retrieveValue(inputs[0]);
+        final Type type = typeHint.retrieveValue(inputs[1]);
+        final Number a = aHint.retrieveValue(inputs[2]);
+        final Number b = bHint.retrieveValue(inputs[3]);
 
-        final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
-        final Mat output = outputSocket.getValue().get();
+        final Socket<Mat> outputSocket = dstHint.safeCastSocket(outputs[0]);
+        final Mat output = dstHint.retrieveValue(outputSocket);
 
         normalize(input, output, a.doubleValue(), b.doubleValue(), type.value, -1, null);
 

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/SwitchOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/SwitchOperation.java
@@ -10,6 +10,8 @@ import edu.wpi.grip.core.sockets.*;
  * boolean {@link InputSocket}
  */
 public class SwitchOperation implements Operation {
+    private final SocketHint<Boolean> switcherHint = SocketHints.createBooleanSocketHint("switch", true);
+
     @Override
     public String getName() {
         return "Switch";
@@ -28,7 +30,7 @@ public class SwitchOperation implements Operation {
     @Override
     public SocketsProvider createSockets(EventBus eventBus) {
         // This hint toggles the switch between using the true and false sockets
-        final SocketHint<Boolean> switcherHint = SocketHints.createBooleanSocketHint("switch", true);
+
 
         final LinkedSocketHint linkedSocketHint = new LinkedSocketHint(eventBus);
         final InputSocket<?>[] inputs = new InputSocket[]{
@@ -55,9 +57,9 @@ public class SwitchOperation implements Operation {
     @Override
     @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final InputSocket<Boolean> switchHint = (InputSocket<Boolean>) inputs[0];
+        final boolean switchVal =  switcherHint.retrieveValue(inputs[0]);
         // If the input is true pass one value through
-        if (switchHint.getValue().get()) {
+        if (switchVal) {
             outputs[0].setValueOptional(((InputSocket) inputs[1]).getValue());
         } else { // Otherwise pass the other one through
             outputs[0].setValueOptional(((InputSocket) inputs[2]).getValue());

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/ThresholdOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/ThresholdOperation.java
@@ -31,7 +31,7 @@ public abstract class ThresholdOperation implements Operation {
      * @param input     The input matrix that the dataArray element should be compared against
      * @return Either the old mat with the value assigned or a newly created Matrix.
      */
-    protected Mat reallocateMatIfInputSizeOrWidthChanged(final Mat[] dataArray, final int index, final Scalar value, final Mat input) {
+    protected static Mat reallocateMatIfInputSizeOrWidthChanged(final Mat[] dataArray, final int index, final Scalar value, final Mat input) {
         if (dataArray[index].size().width() != input.size().width()
                 || dataArray[index].size().height() != input.size().height()
                 || dataArray[index].type() != input.type()) {

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/ValveOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/ValveOperation.java
@@ -8,6 +8,8 @@ import edu.wpi.grip.core.sockets.*;
 import java.util.Optional;
 
 public class ValveOperation implements Operation {
+    // This hint toggles the switch between using the true and false sockets
+    private final SocketHint<Boolean> valveHint = SocketHints.createBooleanSocketHint("valve", true);
     @Override
     public String getName() {
         return "Valve";
@@ -25,12 +27,9 @@ public class ValveOperation implements Operation {
 
     @Override
     public SocketsProvider createSockets(EventBus eventBus) {
-        // This hint toggles the switch between using the true and false sockets
-        final SocketHint<Boolean> switcherHint = SocketHints.createBooleanSocketHint("valve", true);
-
         final LinkedSocketHint linkedSocketHint = new LinkedSocketHint(eventBus);
         final InputSocket<?>[] inputs = new InputSocket[]{
-                new InputSocket<>(eventBus, switcherHint),
+                new InputSocket<>(eventBus, valveHint),
                 linkedSocketHint.linkedInputSocket("Input"),
         };
         final OutputSocket<?>[] outputs = new OutputSocket[]{
@@ -52,9 +51,9 @@ public class ValveOperation implements Operation {
     @Override
     @SuppressWarnings("unchecked")
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final InputSocket<Boolean> switchHint = (InputSocket<Boolean>) inputs[0];
+        final boolean valveValue = valveHint.retrieveValue(inputs[0]);
         // If the input is true pass the value through
-        if (switchHint.getValue().get()) {
+        if (valveValue) {
             outputs[0].setValueOptional(((InputSocket) inputs[1]).getValue());
         } else {
             outputs[0].setValueOptional((Optional) Optional.empty());

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/WatershedOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/WatershedOperation.java
@@ -3,11 +3,8 @@ package edu.wpi.grip.core.operations.composite;
 
 import com.google.common.eventbus.EventBus;
 
-import edu.wpi.grip.core.sockets.InputSocket;
+import edu.wpi.grip.core.sockets.*;
 import edu.wpi.grip.core.Operation;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
 
 import static org.bytedeco.javacpp.opencv_core.*;
 import static org.bytedeco.javacpp.opencv_imgproc.*;
@@ -53,15 +50,15 @@ public class WatershedOperation implements Operation {
 
     @Override
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat input = (Mat) inputs[0].getValue().get();
+        final Mat input = srcHint.retrieveValue(inputs[0]);
         if (input.type() != CV_8UC3) {
             throw new IllegalArgumentException("Watershed only works on 8-bit, 3-channel images");
         }
 
-        final ContoursReport contourReport = (ContoursReport) inputs[1].getValue().get();
+        final ContoursReport contourReport = contoursHint.retrieveValue(inputs[1]);
         final MatVector contours = contourReport.getContours();
 
-        final OutputSocket<Mat> outputSocket = (OutputSocket<Mat>) outputs[0];
+        final Socket<Mat> outputSocket = outputHint.safeCastSocket(outputs[0]);
         final Mat markers = new Mat(input.size(), CV_32SC1, new Scalar(0.0));
         final Mat output = new Mat(markers.size(), CV_8UC1, new Scalar(0.0));
 

--- a/core/src/main/java/edu/wpi/grip/core/operations/opencv/MatFieldAccessor.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/opencv/MatFieldAccessor.java
@@ -1,22 +1,19 @@
 package edu.wpi.grip.core.operations.opencv;
 
 import com.google.common.eventbus.EventBus;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 import org.bytedeco.javacpp.opencv_core.Mat;
 import org.bytedeco.javacpp.opencv_core.Size;
 
 public class MatFieldAccessor implements CVOperation {
     private static final Mat defaultsMat = new Mat();
-    private final SocketHint matHint = SocketHints.Inputs.createMatSocketHint("Input", false);
-    private final SocketHint sizeHint = SocketHints.Inputs.createSizeSocketHint("size", true);
-    private final SocketHint emptyHint = SocketHints.Outputs.createBooleanSocketHint("empty", defaultsMat.empty());
-    private final SocketHint channelsHint = SocketHints.Outputs.createNumberSocketHint("channels", defaultsMat.channels());
-    private final SocketHint colsHint = SocketHints.Outputs.createNumberSocketHint("cols", defaultsMat.rows());
-    private final SocketHint rowsHint = SocketHints.Outputs.createNumberSocketHint("rows", defaultsMat.rows());
-    private final SocketHint highValueHint = SocketHints.Outputs.createNumberSocketHint("high value", defaultsMat.highValue());
+    private final SocketHint<Mat> matHint = SocketHints.Inputs.createMatSocketHint("Input", false);
+    private final SocketHint<Size> sizeHint = SocketHints.Inputs.createSizeSocketHint("size", true);
+    private final SocketHint<Boolean> emptyHint = SocketHints.Outputs.createBooleanSocketHint("empty", defaultsMat.empty());
+    private final SocketHint<Number> channelsHint = SocketHints.Outputs.createNumberSocketHint("channels", defaultsMat.channels());
+    private final SocketHint<Number> colsHint = SocketHints.Outputs.createNumberSocketHint("cols", defaultsMat.rows());
+    private final SocketHint<Number> rowsHint = SocketHints.Outputs.createNumberSocketHint("rows", defaultsMat.rows());
+    private final SocketHint<Number> highValueHint = SocketHints.Outputs.createNumberSocketHint("high value", defaultsMat.highValue());
 
 
     @Override
@@ -31,30 +28,30 @@ public class MatFieldAccessor implements CVOperation {
 
     @Override
     public InputSocket<?>[] createInputSockets(EventBus eventBus) {
-        return new InputSocket[]{new InputSocket(eventBus, matHint)};
+        return new InputSocket[]{new InputSocket<>(eventBus, matHint)};
     }
 
     @Override
     public OutputSocket<?>[] createOutputSockets(EventBus eventBus) {
         return new OutputSocket[]{
-                new OutputSocket(eventBus, sizeHint),
-                new OutputSocket(eventBus, emptyHint),
-                new OutputSocket(eventBus, channelsHint),
-                new OutputSocket(eventBus, colsHint),
-                new OutputSocket(eventBus, rowsHint),
-                new OutputSocket(eventBus, highValueHint)
+                new OutputSocket<>(eventBus, sizeHint),
+                new OutputSocket<>(eventBus, emptyHint),
+                new OutputSocket<>(eventBus, channelsHint),
+                new OutputSocket<>(eventBus, colsHint),
+                new OutputSocket<>(eventBus, rowsHint),
+                new OutputSocket<>(eventBus, highValueHint)
         };
     }
 
     @Override
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final Mat inputMat = (Mat) inputs[0].getValue().get();
-        final OutputSocket<Size> sizeSocket = (OutputSocket<Size>) outputs[0];
-        final OutputSocket<Boolean> isEmptySocket = (OutputSocket<Boolean>) outputs[1];
-        final OutputSocket<Number> channelsSocket = (OutputSocket<Number>) outputs[2];
-        final OutputSocket<Number> colsSocket = (OutputSocket<Number>) outputs[3];
-        final OutputSocket<Number> rowsSocket = (OutputSocket<Number>) outputs[4];
-        final OutputSocket<Number> highValueSocket = (OutputSocket<Number>) outputs[5];
+        final Mat inputMat = matHint.retrieveValue(inputs[0]);
+        final Socket<Size> sizeSocket = sizeHint.safeCastSocket(outputs[0]);
+        final Socket<Boolean> isEmptySocket = emptyHint.safeCastSocket(outputs[1]);
+        final Socket<Number> channelsSocket = channelsHint.safeCastSocket(outputs[2]);
+        final Socket<Number> colsSocket = colsHint.safeCastSocket(outputs[3]);
+        final Socket<Number> rowsSocket = rowsHint.safeCastSocket(outputs[4]);
+        final Socket<Number> highValueSocket = highValueHint.safeCastSocket(outputs[5]);
 
         sizeSocket.setValue(inputMat.size());
         isEmptySocket.setValue(inputMat.empty());

--- a/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewPointOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewPointOperation.java
@@ -2,10 +2,7 @@ package edu.wpi.grip.core.operations.opencv;
 
 
 import com.google.common.eventbus.EventBus;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 import org.bytedeco.javacpp.opencv_core.Point;
 
 import java.io.InputStream;
@@ -36,21 +33,19 @@ public class NewPointOperation implements CVOperation {
 
     @Override
     public InputSocket<?>[] createInputSockets(EventBus eventBus) {
-        return new InputSocket[]{new InputSocket(eventBus, xHint), new InputSocket(eventBus, yHint)};
+        return new InputSocket[]{new InputSocket<>(eventBus, xHint), new InputSocket<>(eventBus, yHint)};
     }
 
     @Override
     public OutputSocket<?>[] createOutputSockets(EventBus eventBus) {
-        return new OutputSocket[]{new OutputSocket(eventBus, outputHint)};
+        return new OutputSocket[]{new OutputSocket<>(eventBus, outputHint)};
     }
 
     @Override
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final InputSocket<Number> xSocket = (InputSocket<Number>) inputs[0];
-        final InputSocket<Number> ySocket = (InputSocket<Number>) inputs[1];
-        final int xValue = xSocket.getValue().get().intValue();
-        final int yValue = ySocket.getValue().get().intValue();
-        final OutputSocket<Point> outputSocket = (OutputSocket<Point>) outputs[0];
+        final int xValue = xHint.retrieveValue(inputs[0]).intValue();
+        final int yValue = yHint.retrieveValue(inputs[1]).intValue();
+        final Socket<Point> outputSocket = outputHint.safeCastSocket(outputs[0]);
         outputSocket.setValue(new Point(xValue, yValue));
     }
 }

--- a/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewSizeOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/opencv/NewSizeOperation.java
@@ -2,10 +2,7 @@ package edu.wpi.grip.core.operations.opencv;
 
 
 import com.google.common.eventbus.EventBus;
-import edu.wpi.grip.core.sockets.InputSocket;
-import edu.wpi.grip.core.sockets.OutputSocket;
-import edu.wpi.grip.core.sockets.SocketHint;
-import edu.wpi.grip.core.sockets.SocketHints;
+import edu.wpi.grip.core.sockets.*;
 import org.bytedeco.javacpp.opencv_core.Size;
 
 import java.io.InputStream;
@@ -34,21 +31,19 @@ public class NewSizeOperation implements CVOperation {
 
     @Override
     public InputSocket<?>[] createInputSockets(EventBus eventBus) {
-        return new InputSocket[]{new InputSocket(eventBus, widthHint), new InputSocket(eventBus, heightHint)};
+        return new InputSocket[]{new InputSocket<>(eventBus, widthHint), new InputSocket<>(eventBus, heightHint)};
     }
 
     @Override
     public OutputSocket<?>[] createOutputSockets(EventBus eventBus) {
-        return new OutputSocket[]{new OutputSocket(eventBus, outputHint)};
+        return new OutputSocket[]{new OutputSocket<>(eventBus, outputHint)};
     }
 
     @Override
     public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
-        final InputSocket<Number> widthSocket = (InputSocket<Number>) inputs[0];
-        final InputSocket<Number> heightSocket = (InputSocket<Number>) inputs[1];
-        final int widthValue = widthSocket.getValue().get().intValue();
-        final int heightValue = heightSocket.getValue().get().intValue();
-        final OutputSocket<Size> outputSocket = (OutputSocket<Size>) outputs[0];
+        final int widthValue = widthHint.retrieveValue(inputs[0]).intValue();
+        final int heightValue = heightHint.retrieveValue(inputs[1]).intValue();
+        final Socket<Size> outputSocket = outputHint.safeCastSocket(outputs[0]);
         outputSocket.setValue(new Size(widthValue, heightValue));
     }
 }

--- a/core/src/main/java/edu/wpi/grip/core/sockets/SocketHints.java
+++ b/core/src/main/java/edu/wpi/grip/core/sockets/SocketHints.java
@@ -52,7 +52,7 @@ public final class SocketHints {
             return createNumberSocketHintBuilder(identifier, number).view(SocketHint.View.TEXT).build();
         }
 
-        public static SocketHint<List> createNumberListRangeSocketHint(final String identifier, final Number low, final Number high) {
+        public static SocketHint<List<Number>> createNumberListRangeSocketHint(final String identifier, final Number low, final Number high) {
             return createNumberListSocketHintBuilder(identifier, new Number[]{low, high})
                     .view(SocketHint.View.RANGE)
                     .build();
@@ -127,8 +127,8 @@ public final class SocketHints {
         else return builder;
     }
 
-    private static SocketHint.Builder<List> createNumberListSocketHintBuilder(final String identifier, final Number[] domain) {
-        return new SocketHint.Builder<>(List.class).identifier(identifier)
+    private static SocketHint.Builder<List<Number>> createNumberListSocketHintBuilder(final String identifier, final Number[] domain) {
+        return new SocketHint.Builder<List<Number>>(List.class).identifier(identifier)
                 .initialValueSupplier(() -> new ArrayList<>(Arrays.asList(domain)))
                 .domain(new List[]{Arrays.asList(domain)});
     }

--- a/core/src/test/java/edu/wpi/grip/core/AddOperation.java
+++ b/core/src/test/java/edu/wpi/grip/core/AddOperation.java
@@ -10,7 +10,7 @@ import org.bytedeco.javacpp.opencv_core.Mat;
  * Performs the opencv add operation
  */
 public class AddOperation implements Operation {
-    private SocketHint<Mat>
+    private final SocketHint<Mat>
             aHint = SocketHints.Inputs.createMatSocketHint("a", false),
             bHint = SocketHints.Inputs.createMatSocketHint("b", false),
             sumHint = SocketHints.Inputs.createMatSocketHint("sum", true);
@@ -28,21 +28,24 @@ public class AddOperation implements Operation {
     @Override
     public InputSocket[] createInputSockets(EventBus eventBus) {
         return new InputSocket[]{
-                new InputSocket<Mat>(eventBus, aHint),
-                new InputSocket<Mat>(eventBus, bHint)
+                new InputSocket<>(eventBus, aHint),
+                new InputSocket<>(eventBus, bHint)
         };
     }
 
     @Override
     public OutputSocket[] createOutputSockets(EventBus eventBus) {
         return new OutputSocket[]{
-                new OutputSocket<Mat>(eventBus, sumHint)
+                new OutputSocket<>(eventBus, sumHint)
         };
     }
 
     @Override
-    public void perform(InputSocket[] inputs, OutputSocket[] outputs) {
-        Socket<Mat> a = inputs[0], b = inputs[1], sum = outputs[0];
-        opencv_core.add(a.getValue().get(), b.getValue().get(), sum.getValue().get());
+    public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
+        final Socket<Mat>
+                a = aHint.safeCastSocket(inputs[0]),
+                b = bHint.safeCastSocket(inputs[1]),
+                sum = sumHint.safeCastSocket(outputs[0]);
+        opencv_core.add(aHint.retrieveValue(a), bHint.retrieveValue(b), sumHint.retrieveValue(sum));
     }
 }

--- a/core/src/test/java/edu/wpi/grip/core/AdditionOperation.java
+++ b/core/src/test/java/edu/wpi/grip/core/AdditionOperation.java
@@ -33,10 +33,9 @@ public class AdditionOperation implements Operation {
     }
 
     @Override
-    public void perform(InputSocket[] inputs, OutputSocket[] outputs) {
-        InputSocket<Number> a = inputs[0], b = inputs[1];
-        OutputSocket<Number> c = outputs[0];
+    public void perform(InputSocket<?>[] inputs, OutputSocket<?>[] outputs) {
+        final Number a = aHint.retrieveValue(inputs[0]), b = bHint.retrieveValue(inputs[1]);
 
-        c.setValue(a.getValue().get().doubleValue() + b.getValue().get().doubleValue());
+        cHint.safeCastSocket(outputs[0]).setValue(a.doubleValue() + b.doubleValue());
     }
 }

--- a/core/src/test/java/edu/wpi/grip/core/sockets/SocketHintTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/sockets/SocketHintTest.java
@@ -1,0 +1,16 @@
+package edu.wpi.grip.core.sockets;
+
+import com.google.common.eventbus.EventBus;
+import org.junit.Test;
+
+public class SocketHintTest {
+
+    @Test(expected = ClassCastException.class)
+    public void safeCastSocketOfInconpatibleType() {
+        final SocketHint<Boolean> booleanSocketHint = SocketHints.createBooleanSocketHint("testBool", false);
+        final SocketHint<Number> numberSocketHint = SocketHints.createNumberSocketHint("testNumb", 0);
+        final InputSocket<Number> numberInputSocket = new InputSocket<>(new EventBus(), numberSocketHint);
+
+         booleanSocketHint.safeCastSocket(numberInputSocket);
+    }
+}


### PR DESCRIPTION
SocketHints already know what type they are so they can be used
to safely perform the casting of the sockets passed to the perform method.