### PR TITLE
Feat/drag and drop operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && ./gradlew :ui:assemble --stacktrace || ./gradlew --stacktrace '
 
 script:
-  - ./gradlew check --stacktrace -PprintTestResults
+  - ./gradlew check --stacktrace -Pheadless=true
 
 after_success:
   - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ install:
   - choco install -y InnoSetup
 
 build_script:
-  - gradlew.bat :ui:assemble --stacktrace -PprintTestResults
+  - gradlew.bat :ui:assemble --stacktrace
 
 # to run your custom scripts instead of automatic tests
 test_script:
-  - gradlew.bat check --stacktrace -PprintTestResults
+  - gradlew.bat check --stacktrace -Pheadless=true
 
 platform:
   - x64

--- a/build.gradle
+++ b/build.gradle
@@ -290,6 +290,7 @@ project(":ui") {
         testCompile files(project(':core').sourceSets.test.output.resourcesDir)
         testCompile group: 'org.testfx', name: 'testfx-core', version: '4.0.+'
         testCompile group: 'org.testfx', name: 'testfx-junit', version: '4.0.+'
+        testRuntime group: 'org.testfx', name: 'openjfx-monocle', version: '1.8.0_20'
     }
 
     evaluationDependsOn(':core')
@@ -298,6 +299,17 @@ project(":ui") {
     idea.module {
         scopes.PROVIDED.plus += [configurations.ideProvider]
     }
+
+    /*
+     * Allows you to run the UI tests in headless mode by calling gradle with the -Pheadless=true argument
+     */
+    if (project.hasProperty('headless') && project.headless) {
+        println "Running UI Tests Headless"
+        test {
+            jvmArgs = ['-Djava.awt.headless=true', '-Dtestfx.robot=glass', '-Dtestfx.headless=true', '-Dprism.order=sw', '-Dprism.text=t2k']
+        }
+    }
+
 
     javafx {
         profiles {

--- a/core/src/test/java/edu/wpi/grip/core/PipelineTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/PipelineTest.java
@@ -275,4 +275,64 @@ public class PipelineTest {
 
         assertFalse("Should not be able to connect incompatible types", pipeline.canConnect((OutputSocket) b, (InputSocket) a));
     }
+
+    @Test
+    public void testAddBetweenSteps() {
+        final Step
+                stepToAdd = new MockStep(),
+                lowerStep = new MockStep(),
+                upperStep = new MockStep();
+        pipeline.addStep(lowerStep);
+        pipeline.addStep(upperStep);
+
+        pipeline.addStepBetween(stepToAdd, lowerStep, upperStep);
+        assertEquals("The step was not added to the middle of the pipeline",
+                Arrays.asList(lowerStep, stepToAdd, upperStep), pipeline.getSteps());
+    }
+
+    @Test
+    public void testAddBetweenNullAndStep() {
+        final Step
+                stepToAdd = new MockStep(),
+                lowerStep = new MockStep(),
+                upperStep = new MockStep();
+        pipeline.addStep(lowerStep);
+        pipeline.addStep(upperStep);
+        pipeline.addStepBetween(stepToAdd, null, lowerStep);
+        assertEquals("The step was not added to the begining of the pipeline",
+                Arrays.asList(stepToAdd, lowerStep, upperStep), pipeline.getSteps());
+    }
+
+    @Test
+    public void testAddBetweenStepAndNull() {
+        final Step
+                stepToAdd = new MockStep(),
+                lowerStep = new MockStep(),
+                upperStep = new MockStep();
+        pipeline.addStep(lowerStep);
+        pipeline.addStep(upperStep);
+        pipeline.addStepBetween(stepToAdd, upperStep, null);
+        assertEquals("The step was not added to the end of the pipeline",
+                Arrays.asList(lowerStep, upperStep, stepToAdd), pipeline.getSteps());
+    }
+
+    @Test
+    public void testAddBetweenTwoNulls() {
+        final Step stepToAdd = new MockStep();
+        pipeline.addStepBetween(stepToAdd, null, null);
+        assertEquals("The step should have been added to the pipeline",
+                Collections.singletonList(stepToAdd), pipeline.getSteps());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testAddBetweenStepsOutOfOrder() {
+        final Step
+                stepToAdd = new MockStep(),
+                lowerStep = new MockStep(),
+                upperStep = new MockStep();
+        pipeline.addStep(lowerStep);
+        pipeline.addStep(upperStep);
+
+        pipeline.addStepBetween(stepToAdd, upperStep, lowerStep);
+    }
 }

--- a/ui/src/main/java/edu/wpi/grip/ui/dragging/DragService.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/dragging/DragService.java
@@ -1,0 +1,56 @@
+package edu.wpi.grip.ui.dragging;
+
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+
+import java.util.Optional;
+
+/**
+ * A service to provide data transfer capabilities between two controllers.
+ * Concrete versions of the service are usually {@link com.google.inject.Singleton Singletons}
+ * so that they can be injected into the two controllers.
+ *
+ * @param <T> The value that the object property holds.
+ */
+public abstract class DragService<T> {
+    private final ObjectProperty<T> dragProperty;
+
+    /**
+     * @param name The name for the {@link SimpleObjectProperty}
+     */
+    public DragService(String name) {
+        this.dragProperty = new SimpleObjectProperty<>(this, name);
+    }
+
+    /**
+     * @return The read only version of this object property.
+     */
+    public ReadOnlyObjectProperty<T> getDragProperty() {
+        return dragProperty;
+    }
+
+    /**
+     * @return The value stored in the object property.
+     */
+    public Optional<T> getValue() {
+        return Optional.ofNullable(dragProperty.get());
+    }
+
+    /**
+     * Begins the drag action
+     *
+     * @param value The value to be transferred during the drag.
+     */
+    public void beginDrag(T value) {
+        this.dragProperty.set(value);
+    }
+
+    /**
+     * This should be called when the drag action is complete.
+     */
+    public void completeDrag() {
+        dragProperty.setValue(null);
+    }
+}

--- a/ui/src/main/java/edu/wpi/grip/ui/dragging/OperationDragService.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/dragging/OperationDragService.java
@@ -1,0 +1,17 @@
+package edu.wpi.grip.ui.dragging;
+
+
+import com.google.inject.Singleton;
+import edu.wpi.grip.core.Operation;
+
+/**
+ * Service for dragging an {@link Operation} from the {@link edu.wpi.grip.ui.pipeline.PipelineController}
+ * to the {@link edu.wpi.grip.ui.pipeline.PipelineController}.
+ */
+@Singleton
+public class OperationDragService extends DragService<Operation> {
+
+    public OperationDragService() {
+        super("operation");
+    }
+}

--- a/ui/src/main/java/edu/wpi/grip/ui/util/StyleClassNameUtility.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/util/StyleClassNameUtility.java
@@ -31,7 +31,34 @@ public final class StyleClassNameUtility {
      * @return The CSS class for the step in the pipeline. To use as a css selector then prepend the string with a '.'
      */
     public static String classNameFor(Step step) {
-        return shortNameFor(step.getOperation()).append("-step").toString();
+        return classNameForStepHolding(step.getOperation());
+    }
+
+    /**
+     * Return the CSS Class name for a {@link Step} that holds this {@link Operation}
+     *
+     * @param operation The operation to get the step's class name for
+     * @return The CSS class for this step. To use as a css selector then prepend the string with a '.'
+     */
+    public static String classNameForStepHolding(Operation operation) {
+        return shortNameFor(operation).append("-step").toString();
+    }
+
+    public static String cssSelectorForOutputSocketHandleOnStepHolding(Operation operation) {
+        return ".pipeline ." + classNameForStepHolding(operation) + " .socket-handle.output";
+    }
+
+    public static String cssSelectorForInputSocketHandleOnStepHolding(Operation operation) {
+        return ".pipeline ." + classNameForStepHolding(operation) + " .socket-handle.input";
+    }
+
+
+    public static String cssSelectorForOutputSocketHandleOn(Step step) {
+        return cssSelectorForOutputSocketHandleOnStepHolding(step.getOperation());
+    }
+
+    public static String cssSelectorForInputSocketHandleOn(Step step) {
+        return cssSelectorForInputSocketHandleOnStepHolding(step.getOperation());
     }
 
     /**

--- a/ui/src/main/resources/edu/wpi/grip/ui/MainWindow.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/MainWindow.fxml
@@ -139,7 +139,7 @@
                     <fx:include source="preview/Previews.fxml"/>
                     <fx:include source="Palette.fxml"/>
                 </SplitPane>
-                <ScrollPane fx:id="bottomPane">
+                <ScrollPane fx:id="bottomPane" fitToHeight="true" fitToWidth="true">
                     <fx:include source="pipeline/Pipeline.fxml" fx:id="pipelineView"/>
                 </ScrollPane>
             </items>

--- a/ui/src/main/resources/edu/wpi/grip/ui/pipeline/Pipeline.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/pipeline/Pipeline.fxml
@@ -1,27 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.lang.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.shape.*?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.Group?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.shape.Rectangle?>
-<StackPane maxWidth="Infinity" maxHeight="Infinity" fx:id="root"
-           fx:controller="edu.wpi.grip.ui.pipeline.PipelineController"
-           styleClass="pipeline" xmlns:fx="http://javafx.com/fxml/1">
+
+<StackPane fx:id="root" maxHeight="Infinity" maxWidth="Infinity" styleClass="pipeline" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.grip.ui.pipeline.PipelineController">
     <children>
-        <HBox>
-            <VBox fillWidth="true">
-                <Label styleClass="pane-title" text="Sources" maxWidth="Infinity"/>
-                <Separator orientation="HORIZONTAL"/>
-                <Pane fx:id="addSourcePane"/>
-                <VBox fx:id="sourcesBox" styleClass="sources"/>
+        <HBox maxWidth="1.7976931348623157E308">
+            <VBox fillWidth="true" maxWidth="1.7976931348623157E308">
+                <Label maxWidth="Infinity" styleClass="pane-title" text="Sources" />
+                <Separator orientation="HORIZONTAL" />
+                <Pane fx:id="addSourcePane" />
+                <VBox fx:id="sourcesBox" styleClass="sources" />
             </VBox>
-            <Separator orientation="VERTICAL"/>
-            <HBox fx:id="stepBox" styleClass="steps" fillHeight="false"/>
+            <Separator orientation="VERTICAL" />
+            <HBox fx:id="stepBox" fillHeight="false" maxWidth="1.7976931348623157E308" styleClass="steps" HBox.hgrow="ALWAYS" />
         </HBox>
         <Group fx:id="connections" mouseTransparent="true">
             <StackPane.alignment>TOP_LEFT</StackPane.alignment>
-            <Rectangle x="0" y="0" width="1" height="1" opacity="0"/>
+            <Rectangle height="1" opacity="0" width="1" x="0" y="0" />
         </Group>
     </children>
 </StackPane>

--- a/ui/src/test/java/edu/wpi/grip/ui/MainWindowTest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/MainWindowTest.java
@@ -1,52 +1,145 @@
 package edu.wpi.grip.ui;
 
 
-import edu.wpi.grip.core.AdditionOperation;
-import edu.wpi.grip.core.PipelineRunner;
+import com.google.common.eventbus.EventBus;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.util.Modules;
+import edu.wpi.grip.core.*;
 import edu.wpi.grip.core.events.OperationAddedEvent;
+import edu.wpi.grip.ui.util.DPIUtility;
+import edu.wpi.grip.ui.util.StyleClassNameUtility;
+import edu.wpi.grip.util.GRIPCoreTestModule;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.stage.Stage;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.testfx.framework.junit.ApplicationTest;
 import org.testfx.matcher.base.NodeMatchers;
 import org.testfx.util.WaitForAsyncUtils;
 
+import static org.junit.Assert.assertEquals;
 import static org.testfx.api.FxAssert.verifyThat;
 
-
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class MainWindowTest extends ApplicationTest {
-
+    private static final String STEP_NOT_ADDED_MSG = "Step was not added to pipeline";
+    private final GRIPCoreTestModule testModule = new GRIPCoreTestModule();
+    private Pipeline pipeline;
     private PipelineRunner pipelineRunner;
+    private Operation addOperation;
+    private AdditionOperation additionOperation;
 
     @Override
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public void start(Stage stage) throws Exception {
-        final Main main = new Main();
-        main.start(stage);
+        testModule.setUp();
 
-        final OperationListController operationList = main.injector.getInstance(OperationListController.class);
-        pipelineRunner = main.injector.getInstance(PipelineRunner.class);
-        operationList.clearOperations();
-        operationList.onOperationAdded(new OperationAddedEvent(new AdditionOperation()));
+        Injector injector = Guice.createInjector(Modules.override(testModule).with(new GRIPUIModule()));
+
+        final Parent root =
+                FXMLLoader.load(Main.class.getResource("MainWindow.fxml"), null, null, injector::getInstance);
+        root.setStyle("-fx-font-size: " + DPIUtility.FONT_SIZE + "px");
+
+        pipeline = injector.getInstance(Pipeline.class);
+        pipelineRunner = injector.getInstance(PipelineRunner.class);
+        final EventBus eventBus = injector.getInstance(EventBus.class);
+
+        addOperation = new AddOperation();
+        additionOperation = new AdditionOperation();
+
+        eventBus.post(new OperationAddedEvent(addOperation));
+        eventBus.post(new OperationAddedEvent(additionOperation));
+
+        stage.setScene(new Scene(root));
+        stage.show();
     }
 
     @After
     public void tearDown() {
+        testModule.tearDown();
         pipelineRunner.stopAsync().awaitTerminated();
     }
 
     @Test
-    @Ignore
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     public void testShouldCreateNewOperationInPipelineView() {
         // Given:
-        clickOn("#add-operation");
+        clickOn(addOperation.getName());
 
         WaitForAsyncUtils.waitForFxEvents();
 
         // Then:
-        verifyThat(".pipeline", NodeMatchers.hasChild(".add-step"));
+        final String cssSelector = "." + StyleClassNameUtility.classNameForStepHolding(addOperation);
+        verifyThat(cssSelector, NodeMatchers.isNotNull());
+        verifyThat(cssSelector, NodeMatchers.isVisible());
+
+        assertEquals(STEP_NOT_ADDED_MSG, 1, pipeline.getSteps().size());
+        assertEquals("Step added was not this addOperation", addOperation, pipeline.getSteps().get(0).getOperation());
+    }
+
+    @Test
+    public void testDragOperationFromPaletteToPipeline() {
+        // Given:
+        drag(addOperation.getName())
+                .dropTo(".steps");
+
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Then:
+        final String cssSelector = "." + StyleClassNameUtility.classNameForStepHolding(addOperation);
+        verifyThat(cssSelector, NodeMatchers.isNotNull());
+        verifyThat(cssSelector, NodeMatchers.isVisible());
+
+        assertEquals(STEP_NOT_ADDED_MSG, 1, pipeline.getSteps().size());
+        assertEquals("Step added was not this addOperation", addOperation, pipeline.getSteps().get(0).getOperation());
+    }
+
+    @Test
+    public void testDragOperationFromPaletteToLeftOfExistingStep() {
+        // Run the same test as before
+        testDragOperationFromPaletteToPipeline();
+
+        // Now add a second step before it
+        drag(additionOperation.getName())
+                // We drag to the input socket hint handle because this will always be on the left side of the
+                // step. This should cause the UI to put the new step on the left side
+                .dropTo(StyleClassNameUtility.cssSelectorForInputSocketHandleOnStepHolding(addOperation));
+
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Then:
+        final String cssSelector = "." + StyleClassNameUtility.classNameForStepHolding(additionOperation);
+        verifyThat(cssSelector, NodeMatchers.isNotNull());
+        verifyThat(cssSelector, NodeMatchers.isVisible());
+
+        assertEquals(STEP_NOT_ADDED_MSG, 2, pipeline.getSteps().size());
+        assertEquals("Step added was not added in the right place in the pipeline",
+                additionOperation, pipeline.getSteps().get(0).getOperation());
+    }
+
+    @Test
+    public void testDragOperationFromPaletteToRightOfExistingStep() {
+        // Run the same test as before
+        testDragOperationFromPaletteToPipeline();
+
+        // Now add a second step after it
+        drag(additionOperation.getName())
+                // We drag to the output socket hint handle because this will always be on the right side of the
+                // step. This should cause the UI to put the new step on the right side
+                .dropTo(StyleClassNameUtility.cssSelectorForOutputSocketHandleOnStepHolding(addOperation));
+
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Then:
+        final String cssSelector = "." + StyleClassNameUtility.classNameForStepHolding(additionOperation);
+        verifyThat(cssSelector, NodeMatchers.isNotNull());
+        verifyThat(cssSelector, NodeMatchers.isVisible());
+
+        assertEquals(STEP_NOT_ADDED_MSG, 2, pipeline.getSteps().size());
+        assertEquals("Step added was not added in the right place in the pipeline",
+                additionOperation, pipeline.getSteps().get(1).getOperation());
     }
 
 

--- a/ui/src/test/java/edu/wpi/grip/ui/pipeline/OutputSocketControllerTest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/pipeline/OutputSocketControllerTest.java
@@ -34,7 +34,7 @@ public class OutputSocketControllerTest extends ApplicationTest {
         initiallyPreviewedOutputSocket = new InitiallyPreviewedOutputSocket("Initially previewed");
 
         final SocketHandleView.Factory socketHandleFactory
-                = socket -> new SocketHandleView(new EventBus(), null, null, new SocketHandleView.DragService(), socket);
+                = socket -> new SocketHandleView(new EventBus(), null, null, new SocketHandleView.SocketDragService(), socket);
         defaultOutputSocketController =
                 new OutputSocketController(socketHandleFactory, outputSocket);
         initiallyPreviewedOutputSocketController =

--- a/ui/src/test/java/edu/wpi/grip/ui/pipeline/PipelineUITest.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/pipeline/PipelineUITest.java
@@ -76,8 +76,8 @@ public class PipelineUITest extends ApplicationTest {
         Step subtractStep = addOperation(1, subtractionOperation);
 
         // When
-        drag(".pipeline ." + StyleClassNameUtility.classNameFor(addStep) + " .socket-handle.output", MouseButton.PRIMARY)
-                .dropTo(".pipeline ." + StyleClassNameUtility.classNameFor(subtractStep) + " .socket-handle.input");
+        drag(StyleClassNameUtility.cssSelectorForOutputSocketHandleOn(addStep), MouseButton.PRIMARY)
+                .dropTo(StyleClassNameUtility.cssSelectorForInputSocketHandleOn(subtractStep));
 
         // Then
         Connection connection = assertStepConnected("The add step did not connect to the subtract step", addStep, subtractStep);

--- a/ui/src/test/java/edu/wpi/grip/ui/util/DebugUtility.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/util/DebugUtility.java
@@ -1,0 +1,36 @@
+package edu.wpi.grip.ui.util;
+
+
+import javafx.scene.Node;
+import javafx.scene.Parent;
+
+/**
+ * Convenient utility for viewing the scene graph in a hierarchical layout.
+ */
+public final class DebugUtility {
+    private DebugUtility() {
+        /* no-op */
+    }
+
+    /**
+     * @param base The root element to start the tree at.
+     * @return A tabbed tree of the scene using each {@link Node nodes} {@link Object#toString()}
+     */
+    public static String sceneGraphToTree(Parent base) {
+        final StringBuilder builder = new StringBuilder();
+        buildSceneGraph(builder, "", base);
+        return builder.toString();
+    }
+
+    private static void buildSceneGraph(StringBuilder builder, String tabs, Node node) {
+        // Append this element to the tree
+        builder.append(tabs).append(node.toString()).append('\n');
+        // If we have a parent node then crawl its scene graph.
+        if (node instanceof Parent) {
+            final Parent nodeAsParent = (Parent) node;
+            nodeAsParent.getChildrenUnmodifiable().forEach(child -> {
+                buildSceneGraph(builder, tabs + "\t", child);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to drag and drop an operation from the palette to the pipeline. The new step will be placed in the pipeline between the two steps it was dropped between.
If dropped on the left or right of a single step it will be placed on side it was dropped on.
If there are no steps in the pipeline it will be added to the pipeline.

This pr includes unit tests of the new functionality.