### PR TITLE
Add support for 16-bit images.

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/HSLThresholdOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/HSLThresholdOperation.java
@@ -22,9 +22,9 @@ import static org.bytedeco.javacpp.opencv_imgproc.cvtColor;
 public class HSLThresholdOperation extends ThresholdOperation {
     private static final Logger logger = Logger.getLogger(HSLThresholdOperation.class.getName());
     private final SocketHint<Mat> inputHint = SocketHints.Inputs.createMatSocketHint("Input", false);
-    private final SocketHint<List> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 180.0);
-    private final SocketHint<List> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 255.0);
-    private final SocketHint<List> luminanceHint = SocketHints.Inputs.createNumberListRangeSocketHint("Luminance", 0.0, 255.0);
+    private final SocketHint<List> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 1);
+    private final SocketHint<List> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 1);
+    private final SocketHint<List> luminanceHint = SocketHints.Inputs.createNumberListRangeSocketHint("Luminance", 0.0, 1);
 
     private final SocketHint<Mat> outputHint = SocketHints.Outputs.createMatSocketHint("Output");
 
@@ -73,14 +73,14 @@ public class HSLThresholdOperation extends ThresholdOperation {
 
         // Intentionally 1, 3, 2. This maps to the HLS open cv expects
         final Scalar lowScalar = new Scalar(
-                channel1.get(0).doubleValue(),
-                channel3.get(0).doubleValue(),
-                channel2.get(0).doubleValue(), 0);
+                channel1.get(0).doubleValue() * 180,
+                channel3.get(0).doubleValue() * 255,
+                channel2.get(0).doubleValue() * 255, 0);
 
         final Scalar highScalar = new Scalar(
-                channel1.get(1).doubleValue(),
-                channel3.get(1).doubleValue(),
-                channel2.get(1).doubleValue(), 0);
+                channel1.get(1).doubleValue() * 180,
+                channel3.get(1).doubleValue() * 255,
+                channel2.get(1).doubleValue() * 255, 0);
 
         final Mat low = reallocateMatIfInputSizeOrWidthChanged(dataArray, 0, lowScalar, input);
         final Mat high = reallocateMatIfInputSizeOrWidthChanged(dataArray, 1, highScalar, input);

--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/HSVThresholdOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/HSVThresholdOperation.java
@@ -24,9 +24,9 @@ public class HSVThresholdOperation extends ThresholdOperation {
 
     private static final Logger logger = Logger.getLogger(HSVThresholdOperation.class.getName());
     private final SocketHint<Mat> inputHint = SocketHints.Inputs.createMatSocketHint("Input", false);
-    private final SocketHint<List> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 180.0);
-    private final SocketHint<List> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 255.0);
-    private final SocketHint<List> valueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Value", 0.0, 255.0);
+    private final SocketHint<List> hueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Hue", 0.0, 1);
+    private final SocketHint<List> saturationHint = SocketHints.Inputs.createNumberListRangeSocketHint("Saturation", 0.0, 1);
+    private final SocketHint<List> valueHint = SocketHints.Inputs.createNumberListRangeSocketHint("Value", 0.0, 1);
 
     private final SocketHint<Mat> outputHint = SocketHints.Outputs.createMatSocketHint("Output");
 
@@ -75,13 +75,13 @@ public class HSVThresholdOperation extends ThresholdOperation {
         final Mat output = outputSocket.getValue().get();
 
         final Scalar lowScalar = new Scalar(
-                channel1.get(0).doubleValue(),
-                channel2.get(0).doubleValue(),
-                channel3.get(0).doubleValue(), 0);
+                channel1.get(0).doubleValue() * 180,
+                channel2.get(0).doubleValue() * 255,
+                channel3.get(0).doubleValue() * 255, 0);
         final Scalar highScalar = new Scalar(
-                channel1.get(1).doubleValue(),
-                channel2.get(1).doubleValue(),
-                channel3.get(1).doubleValue(), 0);
+                channel1.get(1).doubleValue() * 180,
+                channel2.get(1).doubleValue() * 255,
+                channel3.get(1).doubleValue() * 255, 0);
 
         final Mat low = reallocateMatIfInputSizeOrWidthChanged(dataArray, 0, lowScalar, input);
         final Mat high = reallocateMatIfInputSizeOrWidthChanged(dataArray, 1, highScalar, input);

--- a/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/RangeInputSocketController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/RangeInputSocketController.java
@@ -26,7 +26,7 @@ public class RangeInputSocketController extends InputSocketController<List<Numbe
     // The number of decimals to show.
     private final int numDecimals;
     // The maximum number of decimals to show.
-    private final int MAX_DECIMALS = 3;
+    private static final int MAX_DECIMALS = 3;
 
     public interface Factory {
         RangeInputSocketController create(InputSocket<List<Number>> socket);

--- a/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/RangeInputSocketController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/RangeInputSocketController.java
@@ -23,6 +23,11 @@ public class RangeInputSocketController extends InputSocketController<List<Numbe
 
     private final RangeSlider slider;
 
+    // The number of decimals to show.
+    private final int numDecimals;
+    // The maximum number of decimals to show.
+    private final int MAX_DECIMALS = 3;
+
     public interface Factory {
         RangeInputSocketController create(InputSocket<List<Number>> socket);
     }
@@ -50,6 +55,7 @@ public class RangeInputSocketController extends InputSocketController<List<Numbe
 
         final double min = extremes.get(0).doubleValue();
         final double max = extremes.get(1).doubleValue();
+        this.numDecimals = Math.max(MAX_DECIMALS - (int) Math.log10(Math.abs(max - min)), 0);
         final double initialLow = initialValue.get(0).doubleValue();
         final double initialHigh = initialValue.get(1).doubleValue();
 
@@ -97,7 +103,9 @@ public class RangeInputSocketController extends InputSocketController<List<Numbe
     }
 
     private String getLowHighLabelText() {
-        return String.format("%.0f - %.0f", this.slider.getLowValue(), this.slider.getHighValue());
+        return String.format("%." + numDecimals + "f - %." + numDecimals + "f",
+                this.slider.getLowValue(),
+                this.slider.getHighValue());
     }
 
     @Subscribe

--- a/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/SliderInputSocketController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/pipeline/input/SliderInputSocketController.java
@@ -52,12 +52,13 @@ public class SliderInputSocketController extends InputSocketController<Number> {
         this.slider.setMajorTickUnit(max - min);
         this.slider.valueProperty().addListener(o -> this.getSocket().setValue(this.slider.getValue()));
 
+        final int numDecimals = Math.max(3 - (int) Math.log10(max - min), 0);
         // Add a label under the slider to show the exact value
-        this.label = new Label(String.format("%.0f", initialValue));
+        this.label = new Label(String.format("%." + numDecimals + "f", initialValue));
         label.setMaxWidth(Double.MAX_VALUE);
         label.setAlignment(Pos.CENTER);
         this.slider.valueProperty().addListener(observable ->
-                label.setText(String.format("%.0f", this.slider.getValue())));
+                label.setText(String.format("%." + numDecimals + "f", this.slider.getValue())));
     }
 
     @Override

--- a/ui/src/main/java/edu/wpi/grip/ui/util/ImageConverter.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/util/ImageConverter.java
@@ -31,7 +31,7 @@ public final class ImageConverter {
      * @param mat An 8-bit OpenCV Mat containing an image with either 1 or 3 channels
      * @return A JavaFX image, or null for empty
      */
-    public Image convert(Mat mat) {
+    public Image convert(Mat image) {
         /*
          * IMPORTANT!
          * The {@link ImageConverter#image} is a component that may be actively part of the UI
@@ -42,12 +42,26 @@ public final class ImageConverter {
             throw new IllegalStateException("This modifies an FX object. This must be run in the UI Thread");
         }
 
+        // Copy the mat for display so we don't screw up the data
+        Mat mat = image.clone();
+
         final int width = mat.cols();
         final int height = mat.rows();
         final int channels = mat.channels();
 
         assert channels == 3 || channels == 1 :
                 "Only 3-channel BGR images or single-channel grayscale images can be converted";
+
+        // Convert the image to 8-bit for display
+        // (This does not affect the actual data image)
+        switch (mat.depth()) {
+            case CV_16S:
+                mat.convertTo(mat, CV_8S, 1.0 / 256, 0);
+                break;
+            case CV_16U:
+                mat.convertTo(mat, CV_8U, 1.0 / 256, 0);
+                break;
+        }
 
         assert mat.depth() == CV_8U || mat.depth() == CV_8S :
                 "Only images with 8 bits per channel can be previewed";


### PR DESCRIPTION
Currently, only RGBThresholdOperation can support 16-bit images (HSL/HSV can only use 8-bit). Changes to HSL/HSV are only have them look consistent with RGB.
Change sliders to show decimal points for lower values.