### PR TITLE
Improve IntelliJ indexing of additional Maven repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,12 +168,12 @@ project(":core") {
     repositories {
         flatDir {
             dirs 'libs'
-            maven {
-                url = "http://first.wpi.edu/FRC/roborio/maven/development"
-            }
-            maven {
-                url = "https://github.com/WPIRoboticsProjects/rosjava_mvn_repo/raw/master"
-            }
+        }
+        maven {
+            url = "http://first.wpi.edu/FRC/roborio/maven/development"
+        }
+        maven {
+            url = "https://github.com/WPIRoboticsProjects/rosjava_mvn_repo/raw/master"
         }
     }
 


### PR DESCRIPTION
IntelliJ has trouble discovering maven repositories nested within other types of dependency blocks in Gradle build scripts. This is fixed by moving them outside of the 'flatDir' block.