### PR TITLE
Fixes issue with CV_Resize operation have fx socket hint twice

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/CVOperations.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/CVOperations.java
@@ -278,7 +278,7 @@ public class CVOperations {
                         templateFactory.create(
                                 SocketHints.Inputs.createMatSocketHint("src", false),
                                 new SocketHint.Builder<>(Size.class).identifier("dsize").initialValueSupplier(() -> new Size(0, 0)).build(),
-                                SocketHints.Inputs.createNumberSpinnerSocketHint("fx", .25), SocketHints.Inputs.createNumberSpinnerSocketHint("fx", .25),
+                                SocketHints.Inputs.createNumberSpinnerSocketHint("fx", .25), SocketHints.Inputs.createNumberSpinnerSocketHint("fy", .25),
                                 SocketHints.createEnumSocketHint("interpolation", InterpolationFlagsEnum.INTER_LINEAR),
                                 SocketHints.Outputs.createMatSocketHint("dst"),
                                 (src, dsize, fx, fy, interpolation, dst) -> {


### PR DESCRIPTION
Before:
<img width="163" alt="cv_resize_before" src="https://cloud.githubusercontent.com/assets/16124010/15750929/370c215c-28b6-11e6-8113-1c190b48b185.png">
After: 
<img width="166" alt="cv_resize_after" src="https://cloud.githubusercontent.com/assets/16124010/15750941/41fbebb0-28b6-11e6-84d3-691dfac7658f.png">
Note that the blue rectangles are added to draw attention to the correct location and were not present during the running of GRIP. Also the operation worked correctly and the hint text was the only thing that was wrong.
