### PR TITLE
Mac keyboard shortcuts now use command

### DIFF
--- a/ui/src/main/resources/edu/wpi/grip/ui/MainWindow.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/MainWindow.fxml
@@ -20,7 +20,7 @@
             <Menu text="File">
                 <MenuItem text="New" onAction="#newProject">
                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="N" control="DOWN" meta="UP" shift="UP" shortcut="UP"/>
+                        <KeyCodeCombination alt="UP" code="N" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
                     </accelerator>
                     <graphic>
                         <ImageView>
@@ -38,7 +38,7 @@
                 </MenuItem>
                 <MenuItem text="Open" onAction="#openProject">
                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="O" control="DOWN" meta="UP" shift="UP" shortcut="UP"/>
+                        <KeyCodeCombination alt="UP" code="O" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
                     </accelerator>
                     <graphic>
                         <ImageView>
@@ -56,7 +56,7 @@
                 </MenuItem>
                 <MenuItem text="Save" onAction="#saveProject">
                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="S" control="DOWN" meta="UP" shift="UP" shortcut="UP"/>
+                        <KeyCodeCombination alt="UP" code="S" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
                     </accelerator>
                     <graphic>
                         <ImageView>
@@ -74,7 +74,7 @@
                 </MenuItem>
                 <MenuItem text="Save As" onAction="#saveProjectAs">
                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="S" control="DOWN" meta="UP" shift="DOWN" shortcut="UP"/>
+                        <KeyCodeCombination alt="UP" code="S" control="UP" meta="UP" shift="DOWN" shortcut="DOWN"/>
                     </accelerator>
                     <graphic>
                         <ImageView>
@@ -93,14 +93,14 @@
                 <SeparatorMenuItem/>
                 <MenuItem text="Exit" onAction="#quit">
                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="Q" control="DOWN" meta="UP" shift="UP" shortcut="UP"/>
+                        <KeyCodeCombination alt="UP" code="Q" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
                     </accelerator>
                 </MenuItem>
             </Menu>
             <Menu text="Tools">
                 <MenuItem text="Deploy" onAction="#deploy">
                     <accelerator>
-                        <KeyCodeCombination alt="UP" code="R" control="DOWN" meta="UP" shift="UP" shortcut="UP"/>
+                        <KeyCodeCombination alt="UP" code="R" control="UP" meta="UP" shift="UP" shortcut="DOWN"/>
                     </accelerator>
                     <graphic>
                         <ImageView styleClass="menu-graphic">


### PR DESCRIPTION
Mac keyboard shortcuts used control before.  Now they use command.  Windows still uses control.

Tested on OS X 10.11.5 and Window 10.
