### PR TITLE
Update Travis OSX build to use newest image

### DIFF
--- a/.travis-scripts/install.sh
+++ b/.travis-scripts/install.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-
-    # Install some custom requirements on OS X
-    wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-macosx-x64.dmg
-    hdiutil mount jdk-8u92-macosx-x64.dmg
-    sudo installer -pkg /Volumes/JDK\ 8\ Update\ 92/JDK\ 8\ Update\ 92.pkg -target LocalSystem
-else
+if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
+    # Install some custom requirements on Linux if necessary
     export DISPLAY=:99.0
     sh -e /etc/init.d/xvfb start
     pip install --user codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     - os: linux
       jdk: oraclejdk8
     - os: osx
+      osx_image: xcode8
 
 # GCC needs to be 4.8 or higher so that GOMP_4.0 is installed for opencv
 # This is incredibly hard to track down, find the solution for and fix.

--- a/core/src/test/java/edu/wpi/grip/core/util/service/AutoRestartingServiceTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/util/service/AutoRestartingServiceTest.java
@@ -3,18 +3,27 @@ package edu.wpi.grip.core.util.service;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Many of these mock service objects are copied from Guava's test framework.
@@ -27,6 +36,9 @@ public class AutoRestartingServiceTest {
     private Thread executionThread;
     private Throwable thrownByExecutionThread;
     private Executor exceptionCatchingExecutor;
+
+    @Rule
+    public Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
 
     @Before
     public void setUp() {


### PR DESCRIPTION
Java 8 is already installed in the newest image.

https://github.com/travis-ci/docs-travis-ci-com/issues/593