### PR TITLE
Fix project serialization tests

### DIFF
--- a/core/src/test/java/edu/wpi/grip/core/ManualPipelineRunner.java
+++ b/core/src/test/java/edu/wpi/grip/core/ManualPipelineRunner.java
@@ -1,12 +1,14 @@
 package edu.wpi.grip.core;
 
 import com.google.common.eventbus.EventBus;
+import com.google.inject.Inject;
 
 /*
  * Do not extend this class. The object is registered in the constructor
  */
 public final class ManualPipelineRunner extends PipelineRunner {
 
+  @Inject
   public ManualPipelineRunner(EventBus eventBus, Pipeline pipeline) {
     super(eventBus, () -> pipeline);
     // This is fine because it is in a test
@@ -15,7 +17,8 @@ public final class ManualPipelineRunner extends PipelineRunner {
 
   @Override
   public PipelineRunner startAsync() {
-    throw new UnsupportedOperationException();
+    // NOPE
+    return this;
   }
 
   public void runPipeline() {

--- a/core/src/test/java/edu/wpi/grip/core/serialization/ProjectTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/serialization/ProjectTest.java
@@ -6,6 +6,7 @@ import edu.wpi.grip.core.Connection;
 import edu.wpi.grip.core.ManualPipelineRunner;
 import edu.wpi.grip.core.OperationMetaData;
 import edu.wpi.grip.core.Pipeline;
+import edu.wpi.grip.core.PipelineRunner;
 import edu.wpi.grip.core.Step;
 import edu.wpi.grip.core.events.ConnectionAddedEvent;
 import edu.wpi.grip.core.events.OperationAddedEvent;
@@ -77,7 +78,7 @@ public class ProjectTest {
 
     pipeline = injector.getInstance(Pipeline.class);
 
-    pipelineRunner = new ManualPipelineRunner(eventBus, pipeline);
+    pipelineRunner = (ManualPipelineRunner) injector.getInstance(PipelineRunner.class);
 
 
     additionOperation = new OperationMetaData(AdditionOperation.DESCRIPTION, () -> new

--- a/core/src/test/java/edu/wpi/grip/util/GripCoreTestModule.java
+++ b/core/src/test/java/edu/wpi/grip/util/GripCoreTestModule.java
@@ -3,6 +3,8 @@ package edu.wpi.grip.util;
 
 import edu.wpi.grip.core.FileManager;
 import edu.wpi.grip.core.GripCoreModule;
+import edu.wpi.grip.core.ManualPipelineRunner;
+import edu.wpi.grip.core.PipelineRunner;
 import edu.wpi.grip.core.http.GripServer;
 import edu.wpi.grip.core.http.GripServerTest;
 import edu.wpi.grip.core.sources.CameraSource;
@@ -82,6 +84,7 @@ public class GripCoreTestModule extends GripCoreModule {
     // HTTP server injection bindings
     bind(GripServer.JettyServerFactory.class).to(GripServerTest.TestServerFactory.class);
     bind(GripServer.class).asEagerSingleton();
+    bind(PipelineRunner.class).to(ManualPipelineRunner.class);
   }
 
   @Override


### PR DESCRIPTION
It was a threading issue caused by `Project.open` immediately starting the pipeline asynchronously and not overriding the pipeline runner with the mock version.