### PR TITLE
Filter Contours Ratio Rounding

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/FilterContoursOperation.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/FilterContoursOperation.java
@@ -191,7 +191,7 @@ public class FilterContoursOperation implements Operation {
         continue;
       }
 
-      final double ratio = bb.width() / bb.height();
+      final double ratio = (double) bb.width() / bb.height();
       if (ratio < minRatio || ratio > maxRatio) {
         continue;
       }


### PR DESCRIPTION
Fixes Filter Contours to use double division instead of integer division for calculating the ratio. This allows filter contours to have minimum and maximum ratios that are not integer values.