### PR TITLE
Update default roboRIO mDNS address

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
+++ b/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
@@ -136,7 +136,7 @@ public class ProjectSettings implements Cloneable {
   }
 
   private String computeFRCAddress(int teamNumber) {
-    return "roborio-" + teamNumber + "-frc.local";
+    return "roboRIO-" + teamNumber + "-FRC.local";
   }
 
   public int getServerPort() {


### PR DESCRIPTION
closes #536 

Changes the default roboRIO mDNS address to match capitalization as discussed in #536.  