### PR TITLE
Solves deadlocking when opening a saved project

### DIFF
--- a/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
@@ -172,7 +172,7 @@ public class MainWindowController {
           } catch (IOException e) {
             eventBus.post(new UnexpectedThrowableEvent(e, "Failed to load save file"));
           }
-        },"Project Open Thread");
+        }, "Project Open Thread");
         fileOpenThread.setDaemon(true);
         fileOpenThread.start();
       }

--- a/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/MainWindowController.java
@@ -4,6 +4,7 @@ import edu.wpi.grip.core.Palette;
 import edu.wpi.grip.core.Pipeline;
 import edu.wpi.grip.core.PipelineRunner;
 import edu.wpi.grip.core.events.ProjectSettingsChangedEvent;
+import edu.wpi.grip.core.events.UnexpectedThrowableEvent;
 import edu.wpi.grip.core.serialization.Project;
 import edu.wpi.grip.core.settings.ProjectSettings;
 import edu.wpi.grip.core.settings.SettingsProvider;
@@ -153,7 +154,7 @@ public class MainWindowController {
    * pipeline, an "are you sure?" dialog is shown. (TODO)
    */
   @FXML
-  public void openProject() throws IOException {
+  public void openProject() {
     if (showConfirmationDialogAndWait()) {
       final FileChooser fileChooser = new FileChooser();
       fileChooser.setTitle("Open Project");
@@ -165,7 +166,15 @@ public class MainWindowController {
 
       final File file = fileChooser.showOpenDialog(root.getScene().getWindow());
       if (file != null) {
-        project.open(file);
+        Thread fileOpenThread = new Thread(() -> {
+          try {
+            project.open(file);
+          } catch (IOException e) {
+            eventBus.post(new UnexpectedThrowableEvent(e, "Failed to load save file"));
+          }
+        },"Project Open Thread");
+        fileOpenThread.setDaemon(true);
+        fileOpenThread.start();
       }
     }
   }


### PR DESCRIPTION
[//]: # (Please ensure that the "Allow edits from maintainers" checkbox is checked. Thanks!)

Fixes a deadlock when loading a project while an output image is being rendered