### PR TITLE
Fix a potential deadlock on opening a project

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/sockets/SocketImpl.java
+++ b/core/src/main/java/edu/wpi/grip/core/sockets/SocketImpl.java
@@ -50,13 +50,15 @@ public class SocketImpl<T> implements Socket<T> {
   }
 
   @Override
-  public synchronized void setValueOptional(Optional<? extends T> optionalValue) {
+  public void setValueOptional(Optional<? extends T> optionalValue) {
     checkNotNull(optionalValue, "The optional value can not be null");
-    if (optionalValue.isPresent()) {
-      getSocketHint().getType().cast(optionalValue.get());
+    synchronized (this) {
+      if (optionalValue.isPresent()) {
+        getSocketHint().getType().cast(optionalValue.get());
+      }
+      this.value = optionalValue;
+      onValueChanged();
     }
-    this.value = optionalValue;
-    onValueChanged();
     eventBus.post(new SocketChangedEvent(this));
   }
 

--- a/core/src/main/java/edu/wpi/grip/core/sockets/SocketImpl.java
+++ b/core/src/main/java/edu/wpi/grip/core/sockets/SocketImpl.java
@@ -52,10 +52,10 @@ public class SocketImpl<T> implements Socket<T> {
   @Override
   public void setValueOptional(Optional<? extends T> optionalValue) {
     checkNotNull(optionalValue, "The optional value can not be null");
+    if (optionalValue.isPresent()) {
+      getSocketHint().getType().cast(optionalValue.get());
+    }
     synchronized (this) {
-      if (optionalValue.isPresent()) {
-        getSocketHint().getType().cast(optionalValue.get());
-      }
       this.value = optionalValue;
       onValueChanged();
     }


### PR DESCRIPTION
This deadlock is caused by `SocketImpl.setValueOptional` being a synchronized method and posting a SocketChangedEvent that the UI thread tries to handle by locking on the socket when getting it's value.