### PR TITLE
Fix #695

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/sources/CameraSource.java
+++ b/core/src/main/java/edu/wpi/grip/core/sources/CameraSource.java
@@ -285,12 +285,24 @@ public class CameraSource extends Source implements RestartableService {
 
   @Override
   public void stopAndAwait() {
-    stopAsync().cameraService.stopAndAwait();
+    try {
+      stopAsync().cameraService.stopAndAwait();
+    } catch (IllegalStateException e) {
+      if (!cameraService.state().equals(State.FAILED)) {
+        throw e;
+      }
+    }
   }
 
   @Override
   public void stopAndAwait(long timeout, TimeUnit unit) throws TimeoutException {
-    stopAsync().cameraService.stopAndAwait(timeout, unit);
+    try {
+      stopAsync().cameraService.stopAndAwait(timeout, unit);
+    } catch (IllegalStateException e) {
+      if (!cameraService.state().equals(State.FAILED)) {
+        throw e;
+      }
+    }
   }
 
   @Override

--- a/core/src/test/java/edu/wpi/grip/core/sources/CameraSourceTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/sources/CameraSourceTest.java
@@ -286,7 +286,7 @@ public class CameraSourceTest {
       for (int y = 0; y < frameIdx.rows(); y++) {
         for (int x = 0; x < frameIdx.cols(); x++) {
           for (int z = 0; z < frameIdx.channels(); z++) {
-            frameIdx.putDouble(new int[] {y, x, z}, y + x + z);
+            frameIdx.putDouble(new int[]{y, x, z}, y + x + z);
           }
         }
       }

--- a/ui/src/main/java/edu/wpi/grip/ui/analysis/AnalysisController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/analysis/AnalysisController.java
@@ -5,6 +5,7 @@ import edu.wpi.grip.core.Step;
 import edu.wpi.grip.core.StepIndexer;
 import edu.wpi.grip.core.events.BenchmarkEvent;
 import edu.wpi.grip.core.events.RunStoppedEvent;
+import edu.wpi.grip.core.events.StepRemovedEvent;
 import edu.wpi.grip.core.events.TimerEvent;
 import edu.wpi.grip.core.metrics.BenchmarkRunner;
 import edu.wpi.grip.core.metrics.CsvExporter;
@@ -67,7 +68,7 @@ public class AnalysisController {
   private BenchmarkRunner benchmarker;
 
   private final Callback<StepStatisticsEntry, Observable[]> extractor =
-      entry -> new Observable[] {entry.stepProperty(), entry.analysisProperty()};
+      entry -> new Observable[]{entry.stepProperty(), entry.analysisProperty()};
   private final ObservableList<StepStatisticsEntry> tableItems
       = FXCollections.observableArrayList(extractor);
 
@@ -142,7 +143,13 @@ public class AnalysisController {
   }
 
   @Subscribe
-  @SuppressWarnings( {"PMD.UnusedPrivateMethod", "PMD.UnusedFormalParameter"})
+  @SuppressWarnings("PMD.UnusedPrivateMethod")
+  private void onStepRemoved(StepRemovedEvent e) {
+    sampleMap.remove(e.getStep());
+  }
+
+  @Subscribe
+  @SuppressWarnings({"PMD.UnusedPrivateMethod", "PMD.UnusedFormalParameter"})
   private void onPipelineFinish(@Nullable RunStoppedEvent event) {
     double[] averageRunTimes = sortedStream(sampleMap)
         .parallel()


### PR DESCRIPTION
Closes #695 

695 brought up two problems:

1. Removing a step with connections from the pipeline would cause an exception to be thrown; and  
2. Removing a failing camera source would also cause an exception (unrelated to point 1)