### PR TITLE
Add better support for command line arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,6 +260,7 @@ project(":core") {
         testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
         testCompile group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.2.2'
         testCompile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.2'
+        compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'
         // We use the no_aop version of Guice because the aop isn't avaiable in arm java
         // http://stackoverflow.com/a/15235190/3708426
         // https://github.com/google/guice/wiki/OptionalAOP
@@ -274,6 +275,12 @@ project(":core") {
     }
 
     mainClassName = 'edu.wpi.grip.core.Main'
+
+    if (project.hasProperty('args')) {
+        run {
+            args = (project.args.split("\\s+") as List)
+        }
+    }
 
     jar {
         manifest {
@@ -435,6 +442,12 @@ project(":ui") {
         println "Running UI Tests Headless"
         test {
             jvmArgs = ['-Djava.awt.headless=true', '-Dtestfx.robot=glass', '-Dtestfx.headless=true', '-Dprism.order=sw', '-Dprism.text=t2k']
+        }
+    }
+
+    if (project.hasProperty('args')) {
+        run {
+            args = (project.args.split("\\s+") as List)
         }
     }
 

--- a/core/src/main/java/edu/wpi/grip/core/CoreCommandLineHelper.java
+++ b/core/src/main/java/edu/wpi/grip/core/CoreCommandLineHelper.java
@@ -75,7 +75,7 @@ public class CoreCommandLineHelper {
    *
    * @return a CommandLine object that can be queried for command line options and their values
    */
-  @SuppressWarnings({"checkstyle:regexp", "PMD"})
+  @SuppressWarnings({"checkstyle:regexp", "PMD.SystemPrintln"})
   public CommandLine parse(String... args) {
     try {
       DefaultParser parser = new DefaultParser();
@@ -117,7 +117,7 @@ public class CoreCommandLineHelper {
    * Prints the app version and exits the application.
    */
   @VisibleForTesting
-  @SuppressWarnings({"checkstyle:regexp", "PMD"})
+  @SuppressWarnings({"checkstyle:regexp", "PMD.SystemPrintln"})
   void printVersionAndExit() {
     System.out.printf(
         "GRIP version %s%n",

--- a/core/src/main/java/edu/wpi/grip/core/CoreCommandLineHelper.java
+++ b/core/src/main/java/edu/wpi/grip/core/CoreCommandLineHelper.java
@@ -90,7 +90,7 @@ public class CoreCommandLineHelper {
       System.out.println("Incorrect command line arguments: " + e.getMessage());
       printHelpAndExit();
     }
-    throw new AssertionError("This should never be reached");
+    return null; // This is OK -- will only happen in tests
   }
 
   /**

--- a/core/src/main/java/edu/wpi/grip/core/CoreCommandLineHelper.java
+++ b/core/src/main/java/edu/wpi/grip/core/CoreCommandLineHelper.java
@@ -1,0 +1,137 @@
+package edu.wpi.grip.core;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.util.List;
+
+/**
+ * A helper class for command line options for GRIP.
+ */
+public class CoreCommandLineHelper {
+
+  public static final String FILE_OPTION = "f"; // "f" for "file"
+  public static final String PORT_OPTION = "p"; // "p" for "port"
+  public static final String HELP_OPTION = "h"; // "h" for "help" (this is standard)
+  public static final String VERSION_OPTION = "v"; // "v" for "version" (this is standard)
+
+  private final Options options = new Options();
+  private static final Option saveOption =
+      Option.builder(FILE_OPTION)
+          .longOpt("file")
+          .desc("Set the GRIP save file to load")
+          .hasArg()
+          .numberOfArgs(1)
+          .argName("path")
+          .build();
+  private static final Option portOption =
+      Option.builder(PORT_OPTION)
+          .longOpt("port")
+          .desc("Set the port to run the HTTP server on")
+          .hasArg()
+          .numberOfArgs(1)
+          .argName("port")
+          .build();
+  private static final Option helpOption
+      = new Option(HELP_OPTION, "help", false, "Prints the command line options");
+  private static final Option versionOption
+      = new Option(VERSION_OPTION, "version", false, "Prints the version of GRIP");
+
+  /**
+   * Creates a new core commandline helper with the standard options.
+   */
+  public CoreCommandLineHelper() {
+    options.addOption(saveOption);
+    options.addOption(portOption);
+    options.addOption(helpOption);
+    options.addOption(versionOption);
+  }
+
+  /**
+   * Creates a command line helper with all the standard options, plus any additional options
+   * required by subclasses.
+   *
+   * @param additionalOptions additional command line arguments
+   */
+  protected CoreCommandLineHelper(Option... additionalOptions) {
+    this();
+    for (Option o : additionalOptions) {
+      options.addOption(o);
+    }
+  }
+
+  /**
+   * Parses an array of command line arguments. If there are unknown arguments or the arguments are
+   * otherwise malformed, a help message will be printed and the application will exit without
+   * returning from this method. This will also occur if the help option is specified.
+   *
+   * @param args the command line arguments to parse
+   *
+   * @return a CommandLine object that can be queried for command line options and their values
+   */
+  @SuppressWarnings({"checkstyle:regexp", "PMD"})
+  public CommandLine parse(String... args) {
+    try {
+      DefaultParser parser = new DefaultParser();
+      CommandLine parsed = parser.parse(options, args);
+      if (parsed.hasOption(HELP_OPTION)) {
+        printHelpAndExit();
+      } else if (parsed.hasOption(VERSION_OPTION)) {
+        printVersionAndExit();
+      }
+      return parsed;
+    } catch (ParseException e) {
+      System.out.println("Incorrect command line arguments: " + e.getMessage());
+      printHelpAndExit();
+    }
+    throw new AssertionError("This should never be reached");
+  }
+
+  /**
+   * Parses a list of command line arguments. This coverts the list to an array and passes it to
+   * {@link #parse(String[])}.
+   *
+   * @see #parse(String[])
+   */
+  public CommandLine parse(List<String> args) {
+    return parse(args.toArray(new String[args.size()]));
+  }
+
+  /**
+   * Prints a help message for the command line arguments and exits the application.
+   */
+  @VisibleForTesting
+  void printHelpAndExit() {
+    HelpFormatter hf = new HelpFormatter();
+    hf.printHelp("GRIP", options);
+    exit();
+  }
+
+  /**
+   * Prints the app version and exits the application.
+   */
+  @VisibleForTesting
+  @SuppressWarnings({"checkstyle:regexp", "PMD"})
+  void printVersionAndExit() {
+    System.out.printf(
+        "GRIP version %s%n",
+        CoreCommandLineHelper.class.getPackage().getImplementationVersion()
+    );
+    exit();
+  }
+
+  /**
+   * Exits the app. This method only exists so testing can work.
+   */
+  @VisibleForTesting
+  void exit() {
+    System.exit(0);
+  }
+
+}

--- a/core/src/main/java/edu/wpi/grip/core/Main.java
+++ b/core/src/main/java/edu/wpi/grip/core/Main.java
@@ -91,10 +91,10 @@ public class Main {
       }
     }
 
-    // This will thrown an exception if the port specified by the save file is already taken.
-    // Since we have to have the server running to handle remotely loading pipelines and uploading
-    // images, as well as potential HTTP publishing operations, this will cause the program
-    // to exit.
+    // This will throw an exception if the port specified by the save file or command line
+    // argument is already taken. Since we have to have the server running to handle remotely
+    // loading pipelines and uploading images, as well as potential HTTP publishing operations,
+    // this will cause the program to exit.
     gripServer.start();
 
     if (pipelineRunner.state() == Service.State.NEW) {

--- a/core/src/main/java/edu/wpi/grip/core/Main.java
+++ b/core/src/main/java/edu/wpi/grip/core/Main.java
@@ -12,9 +12,12 @@ import edu.wpi.grip.core.sources.GripSourcesHardwareModule;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import com.google.common.util.concurrent.Service;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.util.Modules;
+
+import org.apache.commons.cli.CommandLine;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +50,7 @@ public class Main {
 
   @SuppressWarnings("JavadocMethod")
   public static void main(String[] args) throws IOException, InterruptedException {
+    new CoreCommandLineHelper().parse(args); // Check for help or version before doing anything else
     final Injector injector = Guice.createInjector(Modules.override(new GripCoreModule(),
         new GripFileModule(), new GripSourcesHardwareModule()).with(new GripNetworkModule()));
     injector.getInstance(Main.class).start(args);
@@ -54,23 +58,50 @@ public class Main {
 
   @SuppressWarnings("JavadocMethod")
   public void start(String[] args) throws IOException, InterruptedException {
-    String projectPath = null;
-    if (args.length == 1) {
-      logger.log(Level.INFO, "Loading file " + args[0]);
-      projectPath = args[0];
-    }
 
     operations.addOperations();
     cvOperations.addOperations();
     gripServer.addHandler(pipelineSwitcher);
-    gripServer.start();
 
-    // Open a project from a .grip file specified on the command line
-    if (projectPath != null) {
-      project.open(new File(projectPath));
+    CoreCommandLineHelper commandLineHelper = new CoreCommandLineHelper();
+    CommandLine parsedArgs = commandLineHelper.parse(args);
+
+    // Parse the save file option
+    if (parsedArgs.hasOption(CoreCommandLineHelper.FILE_OPTION)) {
+      // Open a project from a .grip file specified on the command line
+      String file = parsedArgs.getOptionValue(CoreCommandLineHelper.FILE_OPTION);
+      logger.log(Level.INFO, "Loading file " + file);
+      project.open(new File(file));
     }
 
-    pipelineRunner.startAsync();
+    // Set the port AFTER loading the project to override the saved port number
+    if (parsedArgs.hasOption(CoreCommandLineHelper.PORT_OPTION)) {
+      try {
+        int port = Integer.parseInt(parsedArgs.getOptionValue(CoreCommandLineHelper.PORT_OPTION));
+        if (port < 1024 || port > 65535) {
+          logger.warning("Not a valid port: " + port);
+        } else {
+          // Valid port; set it (Note: this doesn't check to see if the port is available)
+          logger.info("Running server on port " + port);
+          gripServer.setPort(port);
+        }
+      } catch (NumberFormatException e) {
+        logger.warning(
+            "Not a valid port: " + parsedArgs.getOptionValue(CoreCommandLineHelper.PORT_OPTION));
+      }
+    }
+
+    // This will thrown an exception if the port specified by the save file is already taken.
+    // Since we have to have the server running to handle remotely loading pipelines and uploading
+    // images, as well as potential HTTP publishing operations, this will cause the program
+    // to exit.
+    gripServer.start();
+
+    if (pipelineRunner.state() == Service.State.NEW) {
+      // Loading a project will start the pipeline, so only start it if a project wasn't specified
+      // as a command line argument.
+      pipelineRunner.startAsync();
+    }
 
     // This is done in order to indicate to the user using the deployment UI that this is running
     logger.log(Level.INFO, "SUCCESS! The project is running in headless mode!");

--- a/core/src/main/java/edu/wpi/grip/core/http/GripServer.java
+++ b/core/src/main/java/edu/wpi/grip/core/http/GripServer.java
@@ -212,10 +212,12 @@ public class GripServer {
    *
    * @param port the new port to run on.
    */
-  private void setPort(int port) {
+  public void setPort(int port) {
     stop();
     server = serverFactory.create(port);
+    server.setHandler(handlers);
     state = State.PRE_RUN;
+    start();
   }
 
   /**
@@ -230,7 +232,6 @@ public class GripServer {
     int port = event.getProjectSettings().getServerPort();
     if (port != getPort()) {
       setPort(port);
-      server.setHandler(handlers);
       start();
     }
   }

--- a/core/src/test/java/edu/wpi/grip/core/CoreCommandLineHelperTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/CoreCommandLineHelperTest.java
@@ -1,0 +1,68 @@
+package edu.wpi.grip.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class CoreCommandLineHelperTest {
+
+  private static class Mock extends CoreCommandLineHelper {
+    @Override
+    void exit() {
+      // NOP
+    }
+  }
+
+  @Test
+  public void testHelp() {
+    boolean[] printed = {false};
+    boolean[] exited = {false};
+    Mock m = new Mock() {
+      @Override
+      void printHelpAndExit() {
+        printed[0] = true;
+        super.printHelpAndExit();
+      }
+
+      @Override
+      void exit() {
+        exited[0] = true;
+      }
+    };
+    m.parse("-h");
+    assertTrue("Help text was not printed", printed[0]);
+    assertTrue("The application didn't exit", exited[0]);
+    printed[0] = false;
+    exited[0] = false;
+    m.parse("--help");
+    assertTrue("Help text was not printed", printed[0]);
+    assertTrue("The application didn't exit", exited[0]);
+  }
+
+  @Test
+  public void testVersion() {
+    boolean[] printed = {false};
+    boolean[] exited = {false};
+    Mock m = new Mock() {
+      @Override
+      void printVersionAndExit() {
+        printed[0] = true;
+        super.printHelpAndExit();
+      }
+
+      @Override
+      void exit() {
+        exited[0] = true;
+      }
+    };
+    m.parse("-v");
+    assertTrue("Version text was not printed", printed[0]);
+    assertTrue("The application didn't exit", exited[0]);
+    printed[0] = false;
+    exited[0] = false;
+    m.parse("--version");
+    assertTrue("Version text was not printed", printed[0]);
+    assertTrue("The application didn't exit", exited[0]);
+  }
+
+}

--- a/core/src/test/java/edu/wpi/grip/core/CoreCommandLineHelperTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/CoreCommandLineHelperTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 public class CoreCommandLineHelperTest {
 
-  private static class Mock extends CoreCommandLineHelper {
+  private static class MockHelper extends CoreCommandLineHelper {
     @Override
     void exit() {
       // NOP
@@ -17,7 +17,7 @@ public class CoreCommandLineHelperTest {
   public void testHelp() {
     boolean[] printed = {false};
     boolean[] exited = {false};
-    Mock m = new Mock() {
+    MockHelper m = new MockHelper() {
       @Override
       void printHelpAndExit() {
         printed[0] = true;
@@ -37,17 +37,22 @@ public class CoreCommandLineHelperTest {
     m.parse("--help");
     assertTrue("Help text was not printed", printed[0]);
     assertTrue("The application didn't exit", exited[0]);
+    printed[0] = false;
+    exited[0] = false;
+    m.parse("--port"); // No value given, should print help text and exit
+    assertTrue("Help text was not printed", printed[0]);
+    assertTrue("The application didn't exit", exited[0]);
   }
 
   @Test
   public void testVersion() {
     boolean[] printed = {false};
     boolean[] exited = {false};
-    Mock m = new Mock() {
+    MockHelper m = new MockHelper() {
       @Override
       void printVersionAndExit() {
         printed[0] = true;
-        super.printHelpAndExit();
+        super.printVersionAndExit();
       }
 
       @Override

--- a/core/src/test/java/edu/wpi/grip/core/CoreSanityTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/CoreSanityTest.java
@@ -26,7 +26,8 @@ public class CoreSanityTest extends AbstractPackageSanityTests {
         AddOperation.class,
         ManualPipelineRunner.class,
         SubtractionOperation.class,
-        Main.class
+        Main.class,
+        CoreCommandLineHelper.class
     ).contains(c));
     setDefault(OutputSocket.class, new MockOutputSocket("Mock Out"));
     setDefault(InputSocket.class, new MockInputSocket("Mock In"));

--- a/ui/src/main/java/edu/wpi/grip/ui/Main.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/Main.java
@@ -1,5 +1,6 @@
 package edu.wpi.grip.ui;
 
+import edu.wpi.grip.core.CoreCommandLineHelper;
 import edu.wpi.grip.core.GripCoreModule;
 import edu.wpi.grip.core.GripFileModule;
 import edu.wpi.grip.core.PipelineRunner;
@@ -22,12 +23,13 @@ import com.google.inject.Injector;
 import com.google.inject.util.Modules;
 import com.sun.javafx.application.PlatformImpl;
 
+import org.apache.commons.cli.CommandLine;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.application.Preloader;
@@ -37,6 +39,7 @@ import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
+
 import javax.inject.Inject;
 
 public class Main extends Application {
@@ -61,7 +64,7 @@ public class Main extends Application {
   @Inject private HttpPipelineSwitcher pipelineSwitcher;
   private Parent root;
   private boolean headless;
-  private List<String> parameters;
+  private CommandLine parsedArgs;
 
   public static void main(String[] args) {
     launch(args);
@@ -69,16 +72,16 @@ public class Main extends Application {
 
   @Override
   public void init() throws IOException {
-    parameters = new ArrayList<>(getParameters().getRaw());
+    UICommandLineHelper commandLineHelper = new UICommandLineHelper();
+    parsedArgs = commandLineHelper.parse(getParameters().getRaw());
 
-    if (parameters.contains("--headless")) {
-      // If --headless was specified on the command line, run in headless mode (only use the core
-      // module)
+    if (parsedArgs.hasOption(UICommandLineHelper.HEADLESS_OPTION)) {
+      // If --headless was specified on the command line,
+      // run in headless mode (only use the core module)
       injector = Guice.createInjector(Modules.override(new GripCoreModule(), new GripFileModule(),
           new GripSourcesHardwareModule()).with(new GripNetworkModule()));
       injector.injectMembers(this);
 
-      parameters.remove("--headless");
       headless = true;
     } else {
       // Otherwise, run with both the core and UI modules, and show the JavaFX stage
@@ -116,12 +119,30 @@ public class Main extends Application {
       notifyPreloader(new Preloader.ProgressNotification(0.9));
 
       // If there was a file specified on the command line, open it immediately
-      if (!parameters.isEmpty()) {
+      if (parsedArgs.hasOption(CoreCommandLineHelper.FILE_OPTION)) {
+        String file = parsedArgs.getOptionValue(CoreCommandLineHelper.FILE_OPTION);
         try {
-          project.open(new File(parameters.get(0)));
+          project.open(new File(file));
         } catch (IOException e) {
-          logger.log(Level.SEVERE, "Error loading file: " + parameters.get(0));
+          logger.log(Level.SEVERE, "Error loading file: " + file);
           throw e;
+        }
+      }
+
+      // Set the port AFTER loading the project to override the setting in the file
+      if (parsedArgs.hasOption(CoreCommandLineHelper.PORT_OPTION)) {
+        try {
+          int port = Integer.parseInt(parsedArgs.getOptionValue(CoreCommandLineHelper.PORT_OPTION));
+          if (port < 1024 || port > 65535) {
+            logger.warning("Not a valid port: " + port);
+          } else {
+            // Valid port; set it (Note: this doesn't check to see if the port is available)
+            logger.info("Running server on port " + port);
+            server.setPort(port);
+          }
+        } catch (NumberFormatException e) {
+          logger.warning(
+              "Not a valid port: " + parsedArgs.getOptionValue(CoreCommandLineHelper.PORT_OPTION));
         }
       }
 

--- a/ui/src/main/java/edu/wpi/grip/ui/UICommandLineHelper.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/UICommandLineHelper.java
@@ -11,10 +11,11 @@ public class UICommandLineHelper extends CoreCommandLineHelper {
 
   public static final String HEADLESS_OPTION = "headless";
 
-  private static final Option headlessOption = Option.builder()
-      .longOpt(HEADLESS_OPTION)
-      .desc("Run in headless mode")
-      .build();
+  private static final Option headlessOption =
+      Option.builder()
+          .longOpt(HEADLESS_OPTION)
+          .desc("Run in headless mode")
+          .build();
 
   public UICommandLineHelper() {
     super(headlessOption);

--- a/ui/src/main/java/edu/wpi/grip/ui/UICommandLineHelper.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/UICommandLineHelper.java
@@ -1,0 +1,23 @@
+package edu.wpi.grip.ui;
+
+import edu.wpi.grip.core.CoreCommandLineHelper;
+
+import org.apache.commons.cli.Option;
+
+/**
+ * Command line helper for the UI. This has all the options of the {@link CoreCommandLineHelper}.
+ */
+public class UICommandLineHelper extends CoreCommandLineHelper {
+
+  public static final String HEADLESS_OPTION = "headless";
+
+  private static final Option headlessOption = Option.builder()
+      .longOpt(HEADLESS_OPTION)
+      .desc("Run in headless mode")
+      .build();
+
+  public UICommandLineHelper() {
+    super(headlessOption);
+  }
+
+}


### PR DESCRIPTION
Set the save file with `-f <path>` or `--file <path>`  
Set the HTTP server port with `-p <port>` or `--port <port>`  
Print the version with `-v` or `--version`  
Print help text with `-h` or `--help`  
Set headless mode with `--headless` (UI only)

Can pass command line args through gradle with `-Pargs="<args>"`

Note: this breaks backwards compatibility with loading files from the command line.