### PR TITLE
Make project settings reflect command-line port option

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/Main.java
+++ b/core/src/main/java/edu/wpi/grip/core/Main.java
@@ -2,12 +2,15 @@ package edu.wpi.grip.core;
 
 import edu.wpi.grip.core.events.ExceptionClearedEvent;
 import edu.wpi.grip.core.events.ExceptionEvent;
+import edu.wpi.grip.core.events.ProjectSettingsChangedEvent;
 import edu.wpi.grip.core.http.GripServer;
 import edu.wpi.grip.core.http.HttpPipelineSwitcher;
 import edu.wpi.grip.core.operations.CVOperations;
 import edu.wpi.grip.core.operations.Operations;
 import edu.wpi.grip.core.operations.network.GripNetworkModule;
 import edu.wpi.grip.core.serialization.Project;
+import edu.wpi.grip.core.settings.ProjectSettings;
+import edu.wpi.grip.core.settings.SettingsProvider;
 import edu.wpi.grip.core.sources.GripSourcesHardwareModule;
 
 import com.google.common.eventbus.EventBus;
@@ -37,6 +40,8 @@ public class Main {
   private Project project;
   @Inject
   private PipelineRunner pipelineRunner;
+  @Inject
+  private SettingsProvider settingsProvider;
   @Inject
   private EventBus eventBus;
   @Inject
@@ -83,7 +88,9 @@ public class Main {
         } else {
           // Valid port; set it (Note: this doesn't check to see if the port is available)
           logger.info("Running server on port " + port);
-          gripServer.setPort(port);
+          ProjectSettings settings = settingsProvider.getProjectSettings().clone();
+          settings.setServerPort(port);
+          eventBus.post(new ProjectSettingsChangedEvent(settings));
         }
       } catch (NumberFormatException e) {
         logger.warning(

--- a/core/src/main/java/edu/wpi/grip/core/http/GripServer.java
+++ b/core/src/main/java/edu/wpi/grip/core/http/GripServer.java
@@ -48,11 +48,17 @@ public class GripServer {
    * Possible lifecycle states of the server.
    */
   public enum State {
-    /** The server has not been started yet. */
+    /**
+     * The server has not been started yet.
+     */
     PRE_RUN,
-    /** The server is currently running. */
+    /**
+     * The server is currently running.
+     */
     RUNNING,
-    /** The server was running and has been stopped. */
+    /**
+     * The server was running and has been stopped.
+     */
     STOPPED
   }
 
@@ -99,6 +105,27 @@ public class GripServer {
    * </pre></code>
    */
   public static final String DATA_PATH = ROOT_PATH + "/data";
+
+  /**
+   * The lowest valid TCP port number.
+   */
+  private static final int MIN_PORT = 1024;
+
+  /**
+   * The highest valid TCP port number.
+   */
+  private static final int MAX_PORT = 65535;
+
+  /**
+   * Checks if the given TCP port is valid for a server to run on. This doesn't check availability.
+   *
+   * @param port the port to check
+   *
+   * @return true if the port is valid, false if not
+   */
+  public static boolean isPortValid(int port) {
+    return port >= MIN_PORT && port <= MAX_PORT;
+  }
 
   public interface JettyServerFactory {
     Server create(int port);
@@ -213,6 +240,9 @@ public class GripServer {
    * @param port the new port to run on.
    */
   public void setPort(int port) {
+    if (!isPortValid(port)) {
+      throw new IllegalArgumentException("Invalid port: " + port);
+    }
     stop();
     server = serverFactory.create(port);
     server.setHandler(handlers);

--- a/core/src/main/java/edu/wpi/grip/core/http/GripServer.java
+++ b/core/src/main/java/edu/wpi/grip/core/http/GripServer.java
@@ -232,7 +232,6 @@ public class GripServer {
     int port = event.getProjectSettings().getServerPort();
     if (port != getPort()) {
       setPort(port);
-      start();
     }
   }
 

--- a/core/src/main/java/edu/wpi/grip/core/http/HttpPipelineSwitcher.java
+++ b/core/src/main/java/edu/wpi/grip/core/http/HttpPipelineSwitcher.java
@@ -1,7 +1,6 @@
 package edu.wpi.grip.core.http;
 
 import edu.wpi.grip.core.serialization.Project;
-import edu.wpi.grip.core.util.GripMode;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -22,13 +21,11 @@ import javax.servlet.http.HttpServletResponse;
 public class HttpPipelineSwitcher extends PedanticHandler {
 
   private final Project project;
-  private final GripMode mode;
 
   @Inject
-  HttpPipelineSwitcher(ContextStore store, Project project, GripMode mode) {
+  HttpPipelineSwitcher(ContextStore store, Project project) {
     super(store, GripServer.PIPELINE_UPLOAD_PATH, true);
     this.project = project;
-    this.mode = mode;
   }
 
   @Override
@@ -41,24 +38,8 @@ public class HttpPipelineSwitcher extends PedanticHandler {
       baseRequest.setHandled(true);
       return;
     }
-    switch (mode) {
-      case HEADLESS:
-        project.open(new String(IOUtils.toByteArray(request.getInputStream()), "UTF-8"));
-        response.setStatus(HttpServletResponse.SC_CREATED);
-        baseRequest.setHandled(true);
-        break;
-      case GUI:
-        // Don't run in GUI mode, it doesn't make much sense and can easily deadlock if pipelines
-        // are rapidly posted.
-        // Intentional fall-through to default
-      default:
-        // Don't know the mode or the mode is unsupported; let the client know
-        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        sendTextContent(response,
-            String.format("GRIP is not in the correct mode: should be HEADLESS, but is %s", mode),
-            CONTENT_TYPE_PLAIN_TEXT);
-        baseRequest.setHandled(true);
-        break;
-    }
+    project.open(new String(IOUtils.toByteArray(request.getInputStream()), "UTF-8"));
+    response.setStatus(HttpServletResponse.SC_CREATED);
+    baseRequest.setHandled(true);
   }
 }

--- a/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
+++ b/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
@@ -43,9 +43,10 @@ public class ProjectSettings implements Cloneable {
   private String deployJvmOptions = "-Xmx50m -XX:-OmitStackTraceInFastThrow "
       + "-XX:+HeapDumpOnOutOfMemoryError";
 
+  // Transient because save files shouldn't be responsible for knowing the server port
   @Setting(label = "Internal server port",
       description = "The port that the internal server should run on.")
-  private int serverPort = 8080;
+  private transient int serverPort = 8080;
 
   public int getTeamNumber() {
     return teamNumber;

--- a/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
+++ b/core/src/main/java/edu/wpi/grip/core/settings/ProjectSettings.java
@@ -1,5 +1,7 @@
 package edu.wpi.grip.core.settings;
 
+import edu.wpi.grip.core.http.GripServer;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
 
@@ -145,7 +147,7 @@ public class ProjectSettings implements Cloneable {
   }
 
   public void setServerPort(@Nonnegative int serverPort) {
-    checkArgument(serverPort >= 1024 && serverPort <= 65535,
+    checkArgument(GripServer.isPortValid(serverPort),
         "Server port must be in the range 1024..65535");
     this.serverPort = serverPort;
   }

--- a/core/src/test/java/edu/wpi/grip/core/http/HttpPipelineSwitcherTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/http/HttpPipelineSwitcherTest.java
@@ -2,7 +2,6 @@ package edu.wpi.grip.core.http;
 
 import edu.wpi.grip.core.serialization.Project;
 import edu.wpi.grip.core.settings.ProjectSettings;
-import edu.wpi.grip.core.util.GripMode;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -46,7 +45,7 @@ public class HttpPipelineSwitcherTest {
         fail("This should not have been called");
       }
     };
-    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project, GripMode.HEADLESS);
+    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project);
     server.addHandler(pipelineSwitcher);
     HttpResponse response = doGet(GripServer.PIPELINE_UPLOAD_PATH);
     EntityUtils.consume(response.getEntity());
@@ -63,7 +62,7 @@ public class HttpPipelineSwitcherTest {
         assertEquals("Payload was not converted correctly", payload, projectXml);
       }
     };
-    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project, GripMode.HEADLESS);
+    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project);
     server.addHandler(pipelineSwitcher);
     HttpResponse response = doPost(GripServer.PIPELINE_UPLOAD_PATH, payload);
     EntityUtils.consume(response.getEntity());
@@ -79,7 +78,7 @@ public class HttpPipelineSwitcherTest {
         didRun[0] = true;
       }
     };
-    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project, GripMode.HEADLESS);
+    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project);
     server.addHandler(pipelineSwitcher);
     HttpResponse response = doPost(GripServer.PIPELINE_UPLOAD_PATH, "dummy data");
     assertEquals("HTTP status should be 201 Created",
@@ -87,23 +86,6 @@ public class HttpPipelineSwitcherTest {
         response.getStatusLine().getStatusCode());
     EntityUtils.consume(response.getEntity());
     assertTrue("Project was not opened", didRun[0]);
-  }
-
-  @Test
-  public void testGui() throws IOException {
-    Project project = new Project() {
-      @Override
-      public void open(String projectXml) {
-        fail("Project should not be opened");
-      }
-    };
-    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project, GripMode.GUI);
-    server.addHandler(pipelineSwitcher);
-    HttpResponse response = doPost(GripServer.PIPELINE_UPLOAD_PATH, "dummy data");
-    assertEquals("HTTP status should be 500 Internal Error",
-        500,
-        response.getStatusLine().getStatusCode());
-    EntityUtils.consume(response.getEntity());
   }
 
   @After

--- a/core/src/test/java/edu/wpi/grip/core/http/HttpPipelineSwitcherTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/http/HttpPipelineSwitcherTest.java
@@ -45,7 +45,7 @@ public class HttpPipelineSwitcherTest {
         fail("This should not have been called");
       }
     };
-    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project);
+    pipelineSwitcher = makePipelineSwitcher();
     server.addHandler(pipelineSwitcher);
     HttpResponse response = doGet(GripServer.PIPELINE_UPLOAD_PATH);
     EntityUtils.consume(response.getEntity());
@@ -62,7 +62,7 @@ public class HttpPipelineSwitcherTest {
         assertEquals("Payload was not converted correctly", payload, projectXml);
       }
     };
-    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project);
+    pipelineSwitcher = makePipelineSwitcher();
     server.addHandler(pipelineSwitcher);
     HttpResponse response = doPost(GripServer.PIPELINE_UPLOAD_PATH, payload);
     EntityUtils.consume(response.getEntity());
@@ -78,7 +78,7 @@ public class HttpPipelineSwitcherTest {
         didRun[0] = true;
       }
     };
-    pipelineSwitcher = new HttpPipelineSwitcher(new ContextStore(), project);
+    pipelineSwitcher = makePipelineSwitcher();
     server.addHandler(pipelineSwitcher);
     HttpResponse response = doPost(GripServer.PIPELINE_UPLOAD_PATH, "dummy data");
     assertEquals("HTTP status should be 201 Created",
@@ -93,6 +93,10 @@ public class HttpPipelineSwitcherTest {
     server.stop();
     server.removeHandler(pipelineSwitcher);
     pipelineSwitcher.releaseContext();
+  }
+
+  private HttpPipelineSwitcher makePipelineSwitcher() {
+    return new HttpPipelineSwitcher(new ContextStore(), project);
   }
 
   private HttpResponse doGet(String path) throws IOException {

--- a/ui/src/main/java/edu/wpi/grip/ui/Main.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/Main.java
@@ -1,10 +1,8 @@
 package edu.wpi.grip.ui;
 
-import edu.wpi.grip.core.CoreCommandLineHelper;
 import edu.wpi.grip.core.GripCoreModule;
 import edu.wpi.grip.core.GripFileModule;
 import edu.wpi.grip.core.PipelineRunner;
-import edu.wpi.grip.core.events.ProjectSettingsChangedEvent;
 import edu.wpi.grip.core.events.UnexpectedThrowableEvent;
 import edu.wpi.grip.core.http.GripServer;
 import edu.wpi.grip.core.http.HttpPipelineSwitcher;
@@ -12,7 +10,6 @@ import edu.wpi.grip.core.operations.CVOperations;
 import edu.wpi.grip.core.operations.Operations;
 import edu.wpi.grip.core.operations.network.GripNetworkModule;
 import edu.wpi.grip.core.serialization.Project;
-import edu.wpi.grip.core.settings.ProjectSettings;
 import edu.wpi.grip.core.settings.SettingsProvider;
 import edu.wpi.grip.core.sources.GripSourcesHardwareModule;
 import edu.wpi.grip.core.util.SafeShutdown;
@@ -28,7 +25,6 @@ import com.sun.javafx.application.PlatformImpl;
 
 import org.apache.commons.cli.CommandLine;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -68,6 +64,7 @@ public class Main extends Application {
   @Inject private HttpPipelineSwitcher pipelineSwitcher;
   private Parent root;
   private boolean headless;
+  private final UICommandLineHelper commandLineHelper = new UICommandLineHelper();
   private CommandLine parsedArgs;
 
   public static void main(String[] args) {
@@ -76,7 +73,6 @@ public class Main extends Application {
 
   @Override
   public void init() throws IOException {
-    UICommandLineHelper commandLineHelper = new UICommandLineHelper();
     parsedArgs = commandLineHelper.parse(getParameters().getRaw());
 
     if (parsedArgs.hasOption(UICommandLineHelper.HEADLESS_OPTION)) {
@@ -142,35 +138,8 @@ public class Main extends Application {
     operations.addOperations();
     cvOperations.addOperations();
 
-    // If there was a file specified on the command line, open it immediately
-    if (parsedArgs.hasOption(CoreCommandLineHelper.FILE_OPTION)) {
-      String file = parsedArgs.getOptionValue(CoreCommandLineHelper.FILE_OPTION);
-      try {
-        project.open(new File(file));
-      } catch (IOException e) {
-        logger.log(Level.SEVERE, "Error loading file: " + file);
-        throw e;
-      }
-    }
-
-    // Set the port AFTER loading the project to override the setting in the file
-    if (parsedArgs.hasOption(CoreCommandLineHelper.PORT_OPTION)) {
-      try {
-        int port = Integer.parseInt(parsedArgs.getOptionValue(CoreCommandLineHelper.PORT_OPTION));
-        if (port < 1024 || port > 65535) {
-          logger.warning("Not a valid port: " + port);
-        } else {
-          // Valid port; set it (Note: this doesn't check to see if the port is available)
-          logger.info("Running server on port " + port);
-          ProjectSettings settings = settingsProvider.getProjectSettings().clone();
-          settings.setServerPort(port);
-          eventBus.post(new ProjectSettingsChangedEvent(settings));
-        }
-      } catch (NumberFormatException e) {
-        logger.warning(
-            "Not a valid port: " + parsedArgs.getOptionValue(CoreCommandLineHelper.PORT_OPTION));
-      }
-    }
+    commandLineHelper.loadFile(parsedArgs, project);
+    commandLineHelper.setServerPort(parsedArgs, settingsProvider, eventBus);
 
     // This will throw an exception if the port specified by the save file or command line
     // argument is already taken. Since we have to have the server running to handle remotely

--- a/ui/src/main/java/edu/wpi/grip/ui/Main.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/Main.java
@@ -4,6 +4,7 @@ import edu.wpi.grip.core.CoreCommandLineHelper;
 import edu.wpi.grip.core.GripCoreModule;
 import edu.wpi.grip.core.GripFileModule;
 import edu.wpi.grip.core.PipelineRunner;
+import edu.wpi.grip.core.events.ProjectSettingsChangedEvent;
 import edu.wpi.grip.core.events.UnexpectedThrowableEvent;
 import edu.wpi.grip.core.http.GripServer;
 import edu.wpi.grip.core.http.HttpPipelineSwitcher;
@@ -11,6 +12,8 @@ import edu.wpi.grip.core.operations.CVOperations;
 import edu.wpi.grip.core.operations.Operations;
 import edu.wpi.grip.core.operations.network.GripNetworkModule;
 import edu.wpi.grip.core.serialization.Project;
+import edu.wpi.grip.core.settings.ProjectSettings;
+import edu.wpi.grip.core.settings.SettingsProvider;
 import edu.wpi.grip.core.sources.GripSourcesHardwareModule;
 import edu.wpi.grip.core.util.SafeShutdown;
 import edu.wpi.grip.ui.util.DPIUtility;
@@ -58,6 +61,7 @@ public class Main extends Application {
   @Inject private EventBus eventBus;
   @Inject private PipelineRunner pipelineRunner;
   @Inject private Project project;
+  @Inject private SettingsProvider settingsProvider;
   @Inject private Operations operations;
   @Inject private CVOperations cvOperations;
   @Inject private GripServer server;
@@ -158,7 +162,9 @@ public class Main extends Application {
         } else {
           // Valid port; set it (Note: this doesn't check to see if the port is available)
           logger.info("Running server on port " + port);
-          server.setPort(port);
+          ProjectSettings settings = settingsProvider.getProjectSettings().clone();
+          settings.setServerPort(port);
+          eventBus.post(new ProjectSettingsChangedEvent(settings));
         }
       } catch (NumberFormatException e) {
         logger.warning(


### PR DESCRIPTION
No longer serializes the server port. Use the command-line option or the settings dialog to set it. Fixes #708

Enable projects to be uploaded via HTTP in UI mode