### PR TITLE
Fix removing webcams in OSX hanging

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/sources/CameraSource.java
+++ b/core/src/main/java/edu/wpi/grip/core/sources/CameraSource.java
@@ -351,14 +351,14 @@ public class CameraSource extends Source implements RestartableService {
         // won't be freed and new sources won't be able to connect to the webcam until the
         // application is closed.
         if (StandardSystemProperty.OS_NAME.value().toLowerCase().contains("mac")) {
-          // There's a bug with the OS X camera capture that makes the deallocator not return
-          // properly. Use only stopAsync() to avoid blocking. Since we have no way of knowing when
-          // the webcam has actually been freed, we use a dumb delay to try to make sure the webcam
-          // is freed before returning. THIS IS NOT A GOOD SOLUTION. But it's the best one we have
+          // Workaround for #716. This affects webcams as well as IP camera sources.
+          // Use only stopAsync() to avoid blocking. Since we have no way of knowing when
+          // the capture has actually been freed, we use a dumb delay to try to make sure it's
+          // freed before returning. THIS IS NOT A GOOD SOLUTION. But it's the best one we have
           // until the bug is fixed.
-          // The bugged native method: https://github.com/opencv/opencv/blob/master/modules/videoio/src/cap_qtkit.mm#L313-L329
           stopAsync();
           try {
+            // Wait a bit to try to make sure the capture is actually freed before returning
             Thread.sleep(100);
           } catch (InterruptedException ignore) {
             // We did our best. Hopefully, the webcam has been freed at this point.


### PR DESCRIPTION
Use `stopAsync()` and a thread sleep on OS X instead of `stopAndAwait()` due to a bug in the OpenCV camera capture class.

This closes #712