### PR TITLE
Avoid name resolution issue in C++ code generation

### DIFF
--- a/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/cpp/operations/Blur.vm
+++ b/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/cpp/operations/Blur.vm
@@ -12,18 +12,18 @@
 		switch(type) {
 			case BOX:
 				kernelSize = 2 * radius + 1;
-				blur(input,output,Size(kernelSize, kernelSize));
+				cv::blur(input,output,Size(kernelSize, kernelSize));
 				break;
 			case GAUSSIAN:
 				kernelSize = 6 * radius + 1;
-				GaussianBlur(input, output, Size(kernelSize, kernelSize), radius);
+				cv::GaussianBlur(input, output, Size(kernelSize, kernelSize), radius);
 				break;
 			case MEDIAN:
 				kernelSize = 2 * radius + 1;
-				medianBlur(input, output, kernelSize);
+				cv::medianBlur(input, output, kernelSize);
 				break;
 			case BILATERAL:
-				bilateralFilter(input, output, -1, radius, radius);
+				cv::bilateralFilter(input, output, -1, radius, radius);
 				break;
         }
 	}


### PR DESCRIPTION
Found a simple issue with the C++ code generation, where a class method named blur, was causing a name resolution error. The easiest fix was to explicitly use the cv:: namespace in the generated code. It would probably be best to not even use the using namespace (especially as currently done in a header file) and always used explicit namespaces in the generated code.

