### PR TITLE
Don't load BeanInfo classes when finding XStream aliases

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/serialization/Project.java
+++ b/core/src/main/java/edu/wpi/grip/core/serialization/Project.java
@@ -59,6 +59,7 @@ public class Project {
       cp.getAllClasses()
           .stream()
           .filter(ci -> ci.getPackageName().startsWith("edu.wpi.grip"))
+          .filter(ci -> !ci.getName().contains("BeanInfo")) // No BeanInfo classes in embedded JREs
           .map(ClassPath.ClassInfo::load)
           .filter(clazz -> clazz.isAnnotationPresent(XStreamAlias.class))
           .forEach(clazz -> {


### PR DESCRIPTION
Closes #717