### PR TITLE
Use Grgit instead of command-line Git invocation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,10 @@ plugins {
     id 'com.google.osdetector' version '1.4.0'
     id 'com.github.johnrengelman.shadow' version '1.2.3'
     id "com.dorongold.task-tree" version "1.2.2"
+    id 'org.ajoberstar.grgit' version '1.6.0' apply false
 }
 apply plugin: 'nebula-aggregate-javadocs'
+apply from: 'git.gradle'
 
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
@@ -46,15 +48,6 @@ allprojects {
     tasks.withType(CreateStartScripts) {
         mainClassName = "someRandomGiberish" + Math.random()
     }
-}
-
-def getGitCommit = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
 }
 
 idea.project {
@@ -78,40 +71,12 @@ idea.project {
  */
 def getVersionName = { ->
     if (project.hasProperty("vers")) return vers
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--tags'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim().substring(1)
-    } catch (org.gradle.process.internal.ExecException e) {
-        if (!new File(rootDir, '.git/HEAD').exists()) {
-            println("WARN: Could not fetch Git Tag for build version. No Git HEAD available. Substituting version 0.0.0")
-            return "0.0.0"
-        }
-        println("WARN: Could not fetch Git Tag for build version. Please install Git and add it to your PATH. For now, the Git commit hash has been substituted.")
-        return getGitCommit()
-    }
+    return getGitDescribe()
 }
 
 def getVersionSimple = { ->
     if (project.hasProperty("vers")) return vers
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'describe', '--tags', '--abbrev=0'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim().substring(1)
-    } catch (org.gradle.process.internal.ExecException e) {
-        if (!new File(rootDir, '.git/HEAD').exists()) {
-            println("WARN: Could not fetch Git Tag for build version. No Git HEAD available. Substituting version 0.0.0")
-            return "0.0.0"
-        }
-        println("WARN: Could not fetch Git Tag for build version. Please install Git and add it to your PATH. For now, the Git commit hash has been substituted.")
-        return getGitCommit()
-    }
+    return getGitDescribeAbbrev()
 }
 
 configure(subprojects - project(':ui:linuxLauncher')) {

--- a/git.gradle
+++ b/git.gradle
@@ -1,0 +1,20 @@
+def git_provided = false
+if (rootProject.file(".git").exists()) {
+    git_provided = true
+    project.apply plugin: 'org.ajoberstar.grgit'
+}
+
+ext.getGitCommit = { ->
+    if (git_provided) return grgit.head().abbreviatedId
+    return "<no commit>"
+}
+
+ext.getGitDescribe = { ->
+    if (git_provided) return grgit.describe()
+    return "v0.0.0"
+}
+
+ext.getGitDescribeAbbrev = { ->
+    if (git_provided) return grgit.tag.list().last().getName()
+    return "v0.0.0"
+}


### PR DESCRIPTION
This should fix all accounts where Git is not on the path. For cases where Git is not present, we return the commit as `<no commit>` and the Git tag/version as `v0.0.0`