### PR TITLE
opencv-python package is broken; disable python codegen tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   # will not be able to run MainWindowTest.testDragOperationFromPaletteToPipeline
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]];
-    then ./gradlew check jacocoTestReport jacocoRootReport --stacktrace -Pheadless=true -PlogTests -Dscan -Pgeneration -PjniLocation=$HOME/opencv/jni;
+    then ./gradlew check jacocoTestReport jacocoRootReport --stacktrace -Pheadless=true -PlogTests -Dscan -Pgeneration -PjniLocation=$HOME/opencv/jni -PjvmArgs=["-Dcodegen.python.disabled=true"];
     else ./gradlew check jacocoTestReport jacocoRootReport --stacktrace -Pheadless=true -PlogTests -Dscan;
     fi
 

--- a/ui/src/test/java/edu/wpi/grip/ui/codegeneration/AbstractGenerationTesting.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/codegeneration/AbstractGenerationTesting.java
@@ -7,13 +7,11 @@ import edu.wpi.grip.core.operations.network.MockGripNetworkModule;
 import edu.wpi.grip.core.sockets.InputSocket;
 import edu.wpi.grip.core.sockets.OutputSocket;
 import edu.wpi.grip.core.sources.ImageFileSource;
-//import edu.wpi.grip.ui.codegeneration.tools.CppPipelineInterfacer;
 import edu.wpi.grip.ui.codegeneration.tools.HelperTools;
 import edu.wpi.grip.ui.codegeneration.tools.JavaPipelineInterfacer;
 import edu.wpi.grip.ui.codegeneration.tools.PipelineCreator;
 import edu.wpi.grip.ui.codegeneration.tools.PipelineGenerator;
 import edu.wpi.grip.ui.codegeneration.tools.PipelineInterfacer;
-import edu.wpi.grip.ui.codegeneration.tools.PythonPipelineInterfacer;
 import edu.wpi.grip.util.GripCoreTestModule;
 import edu.wpi.grip.util.ImageWithData;
 
@@ -85,9 +83,13 @@ public class AbstractGenerationTesting {
     try {
       JavaPipelineInterfacer jpip = new JavaPipelineInterfacer(fileName + ".java");
       test.accept(jpip);
-      current = Language.PYTHON;
-      PythonPipelineInterfacer ppip = new PythonPipelineInterfacer(fileName);
-      test.accept(ppip);
+
+      // The opencv-python package is broken, so python tests won't work on Travis
+      //current = Language.PYTHON;
+      //PythonPipelineInterfacer ppip = new PythonPipelineInterfacer(fileName);
+      //test.accept(ppip);
+
+      // C++ is just plain broken
       //current = Language.CPP;
       //CppPipelineInterfacer cpip = new CppPipelineInterfacer(fileName);
       //test.accept(cpip);

--- a/ui/src/test/java/edu/wpi/grip/ui/codegeneration/AbstractGenerationTesting.java
+++ b/ui/src/test/java/edu/wpi/grip/ui/codegeneration/AbstractGenerationTesting.java
@@ -12,6 +12,7 @@ import edu.wpi.grip.ui.codegeneration.tools.JavaPipelineInterfacer;
 import edu.wpi.grip.ui.codegeneration.tools.PipelineCreator;
 import edu.wpi.grip.ui.codegeneration.tools.PipelineGenerator;
 import edu.wpi.grip.ui.codegeneration.tools.PipelineInterfacer;
+import edu.wpi.grip.ui.codegeneration.tools.PythonPipelineInterfacer;
 import edu.wpi.grip.util.GripCoreTestModule;
 import edu.wpi.grip.util.ImageWithData;
 
@@ -81,13 +82,16 @@ public class AbstractGenerationTesting {
     gen.export(fileName);
     Language current = Language.JAVA;
     try {
-      JavaPipelineInterfacer jpip = new JavaPipelineInterfacer(fileName + ".java");
-      test.accept(jpip);
+      if (Boolean.valueOf(System.getProperty("codegen.java.disabled", "false"))) {
+        JavaPipelineInterfacer jpip = new JavaPipelineInterfacer(fileName + ".java");
+        test.accept(jpip);
+      }
 
-      // The opencv-python package is broken, so python tests won't work on Travis
-      //current = Language.PYTHON;
-      //PythonPipelineInterfacer ppip = new PythonPipelineInterfacer(fileName);
-      //test.accept(ppip);
+      if (Boolean.valueOf(System.getProperty("codegen.python.disabled", "false"))) {
+        current = Language.PYTHON;
+        PythonPipelineInterfacer ppip = new PythonPipelineInterfacer(fileName);
+        test.accept(ppip);
+      }
 
       // C++ is just plain broken
       //current = Language.CPP;


### PR DESCRIPTION
This should be reverted once the package works again.

See #761 