### PR TITLE
Release converted images in GrabberService after they're no longer used

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/sources/GrabberService.java
+++ b/core/src/main/java/edu/wpi/grip/core/sources/GrabberService.java
@@ -86,6 +86,7 @@ public class GrabberService extends AbstractExecutionThreadService {
     }
 
     updater.copyNewMat(frameMat);
+    frameMat.release();
 
     stopwatch.stop();
     final long elapsedTime = stopwatch.elapsed(TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Helps relieve some memory pressure.
Could help #783