### PR TITLE
Fixed Issue #893

### DIFF
--- a/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/python/operations/CV_Sobel.vm
+++ b/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/python/operations/CV_Sobel.vm
@@ -10,5 +10,5 @@
         Returns:
             The result as a numpy.ndarray.
         """
-        return cv2.Sobel(src, 0, (int)(dx + 0.5), (int)(dy + 0.5), (int)(k_size + 0.5),
+        return cv2.Sobel(src, 0, (int)(dx + 0.5), (int)(dy + 0.5), ksize = (int)(k_size + 0.5),
                             scale = scale, delta = delta, borderType = border_type)


### PR DESCRIPTION
[//]: # (Please ensure that the "Allow edits from maintainers" checkbox is checked. Thanks!)
Fixed Issue #893 so that cv2.Sobel doesn't ignore kernel size and use default of 3.