### PR TITLE
Disable code generation tests on Travis

### DIFF
--- a/.travis-scripts/osx-opencv-install.sh
+++ b/.travis-scripts/osx-opencv-install.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-brew update
-brew install gcc
-brew upgrade gcc
-brew install cmake
-brew upgrade cmake
-brew install ant
-brew upgrade ant
-brew install python3
-brew linkapps python3
-pip3 install numpy
-pip3 install opencv-python
-mkdir -p $HOME/opencv/jni
+#brew update
+#brew install gcc
+#brew upgrade gcc
+#brew install cmake
+#brew upgrade cmake
+#brew install ant
+#brew upgrade ant
+#brew install python3
+#brew linkapps python3
+#pip3 install numpy
+#pip3 install opencv-python
+#mkdir -p $HOME/opencv/jni

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.8
-      - g++-4.8
+#      - gcc-4.8
+#      - g++-4.8
       - oracle-java8-installer
-      - python3
+#      - python3
 before_install:
   - .travis-scripts/install.sh
   - |
@@ -36,11 +36,7 @@ install:
 script:
   # Only run code generation tests on OSX -- linux requires sudo to install OpenCV dependencies, and that environment
   # will not be able to run MainWindowTest.testDragOperationFromPaletteToPipeline
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]];
-    then ./gradlew check jacocoTestReport jacocoRootReport --stacktrace -Pheadless=true -PlogTests --scan -Pgeneration -PjniLocation=$HOME/opencv/jni;
-    else ./gradlew check jacocoTestReport jacocoRootReport --stacktrace -Pheadless=true -PlogTests --scan;
-    fi
+  - ./gradlew check jacocoTestReport jacocoRootReport --stacktrace -Pheadless=true -PlogTests --scan;
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then codecov         ; fi


### PR DESCRIPTION
The mac builds hang on installing GCC or make. Disabling this makes the builds work, though the code generation tests will no longer run.