### PR TITLE
Make generated find_lines python script include first line when run

### DIFF
--- a/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/python/operations/Find_Lines.vm
+++ b/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/python/operations/Find_Lines.vm
@@ -15,7 +15,7 @@
             lines = detector.detect(tmp)
         output = []
         if len(lines) != 0:
-            for i in range(1, len(lines[0])):
+            for i in range(0, len(lines[0])):
                 tmp = ${className}.Line(lines[0][i, 0][0], lines[0][i, 0][1],
                                 lines[0][i, 0][2], lines[0][i, 0][3])
                 output.append(tmp)


### PR DESCRIPTION
Fixes #908 