### PR TITLE
Initialize sources loaded from save file before firing event

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/serialization/SourceConverter.java
+++ b/core/src/main/java/edu/wpi/grip/core/serialization/SourceConverter.java
@@ -60,8 +60,7 @@ public class SourceConverter implements Converter {
       source.initializeSafely();
 
       // Instead of returning the source, post it to the event bus so both the core and GUI
-      // classes know it
-      // exists.
+      // classes know it exists.
       eventBus.post(new SourceAddedEvent(source));
 
       return null;

--- a/core/src/main/java/edu/wpi/grip/core/serialization/SourceConverter.java
+++ b/core/src/main/java/edu/wpi/grip/core/serialization/SourceConverter.java
@@ -54,15 +54,15 @@ public class SourceConverter implements Converter {
       // are in the process of loading.
       final Source source = sourceFactory.create(sourceClass, properties);
 
-      // Instead of returning the source, post it to the event bus so both the core and GUI
-      // classes know it
-      // exists.
-      eventBus.post(new SourceAddedEvent(source));
-
       // Now that the source has been added it needs to be initialized
       // We do it safely here in case the source has changed in some way out
       // of our control. For example, if a webcam is no longer available.
       source.initializeSafely();
+
+      // Instead of returning the source, post it to the event bus so both the core and GUI
+      // classes know it
+      // exists.
+      eventBus.post(new SourceAddedEvent(source));
 
       return null;
     } catch (IOException | RuntimeException ex) {


### PR DESCRIPTION
Fixes a problem with video file sources loaded from a save file not having play/pause and scrubber controls

Closes #913 