### PR TITLE
Add contour angle to contours report

### DIFF
--- a/core/src/main/java/edu/wpi/grip/core/operations/composite/ContoursReport.java
+++ b/core/src/main/java/edu/wpi/grip/core/operations/composite/ContoursReport.java
@@ -85,9 +85,7 @@ public final class ContoursReport implements Publishable {
   }
 
   /**
-   * Compute the bounding boxes of all contours (if they haven't already been computed).  Bounding
-   * boxes are used to compute several different properties, so it's probably not a good idea to
-   * compute them over and over again.
+   * Compute the bounding boxes of all contours. Called lazily and cached by {@link #boundingBoxes}.
    */
   private Rect[] computeBoundingBoxes() {
     return PointerStream.ofMatVector(contours)
@@ -95,6 +93,10 @@ public final class ContoursReport implements Publishable {
         .toArray(Rect[]::new);
   }
 
+  /**
+   * Computes the minimum-area bounding boxes of all contours. Called lazily and cached by
+   * {@link #rotatedBoundingBoxes}.
+   */
   private RotatedRect[] computeMinAreaBoundingBoxes() {
     return PointerStream.ofMatVector(contours)
         .map(opencv_imgproc::minAreaRect)

--- a/core/src/main/java/edu/wpi/grip/core/util/LazyInit.java
+++ b/core/src/main/java/edu/wpi/grip/core/util/LazyInit.java
@@ -1,0 +1,44 @@
+package edu.wpi.grip.core.util;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * A holder for data that gets lazily initialized.
+ *
+ * @param <T> the type of held data
+ */
+public class LazyInit<T> {
+
+  private T value = null;
+  private final Supplier<? extends T> factory;
+
+  /**
+   * Creates a new lazily initialized data holder.
+   *
+   * @param factory the factory to use to create the held value
+   */
+  public LazyInit(Supplier<? extends T> factory) {
+    this.factory = Objects.requireNonNull(factory, "factory");
+  }
+
+  /**
+   * Gets the value, initializing it if it has not yet been created.
+   *
+   * @return the held value
+   */
+  public T get() {
+    if (value == null) {
+      value = factory.get();
+    }
+    return value;
+  }
+
+  /**
+   * Clears the held value. The next call to {@link #get()} will re-instantiate the held value.
+   */
+  public void clear() {
+    value = null;
+  }
+
+}

--- a/core/src/main/java/edu/wpi/grip/core/util/PointerStream.java
+++ b/core/src/main/java/edu/wpi/grip/core/util/PointerStream.java
@@ -12,6 +12,10 @@ import static org.bytedeco.javacpp.opencv_core.MatVector;
  */
 public final class PointerStream {
 
+  private PointerStream() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
   /**
    * Creates a stream of {@code Mat} objects in a {@code MatVector}.
    *

--- a/core/src/main/java/edu/wpi/grip/core/util/PointerStream.java
+++ b/core/src/main/java/edu/wpi/grip/core/util/PointerStream.java
@@ -1,0 +1,26 @@
+package edu.wpi.grip.core.util;
+
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static org.bytedeco.javacpp.opencv_core.Mat;
+import static org.bytedeco.javacpp.opencv_core.MatVector;
+
+/**
+ * Utility class for streaming native vector wrappers like {@code MatVector}
+ * ({@code std::vector<T>}) with the Java {@link Stream} API.
+ */
+public final class PointerStream {
+
+  /**
+   * Creates a stream of {@code Mat} objects in a {@code MatVector}.
+   *
+   * @param vector the vector of {@code Mats} to stream
+   *
+   * @return a new stream object for the contents of the vector
+   */
+  public static Stream<Mat> ofMatVector(MatVector vector) {
+    return LongStream.range(0, vector.size())
+        .mapToObj(vector::get);
+  }
+}

--- a/core/src/test/java/edu/wpi/grip/core/util/LazyInitTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/util/LazyInitTest.java
@@ -1,0 +1,45 @@
+package edu.wpi.grip.core.util;
+
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+public class LazyInitTest {
+
+  @Test
+  public void testFactoryIsOnlyCalledOnce() {
+    final String output = "foo";
+    final int[] count = {0};
+    final Supplier<String> factory = () -> {
+      count[0]++;
+      return output;
+    };
+
+    LazyInit<String> lazyInit = new LazyInit<>(factory);
+    lazyInit.get();
+    assertEquals(1, count[0]);
+
+    lazyInit.get();
+    assertEquals("Calling get() more than once should only call the factory once", 1, count[0]);
+  }
+
+  @Test
+  public void testClear() {
+    final String output = "foo";
+    final int[] count = {0};
+    final Supplier<String> factory = () -> {
+      count[0]++;
+      return output;
+    };
+    LazyInit<String> lazyInit = new LazyInit<>(factory);
+    lazyInit.get();
+    assertEquals(1, count[0]);
+
+    lazyInit.clear();
+    lazyInit.get();
+    assertEquals(2, count[0]);
+  }
+
+}

--- a/core/src/test/java/edu/wpi/grip/core/util/PointerStreamTest.java
+++ b/core/src/test/java/edu/wpi/grip/core/util/PointerStreamTest.java
@@ -1,0 +1,38 @@
+package edu.wpi.grip.core.util;
+
+import org.bytedeco.javacpp.opencv_core.MatVector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PointerStreamTest {
+
+  private MatVector vector;
+
+  @Before
+  public void setupVector() {
+    vector = new MatVector();
+  }
+
+  @After
+  public void freeVector() {
+    vector.deallocate();
+  }
+
+  @Test
+  public void testStreamEmptyMatVector() {
+    vector.resize(0);
+    long size = PointerStream.ofMatVector(vector).count();
+    assertEquals("MatVector of size 0 should result in an empty stream", 0, size);
+  }
+
+  @Test
+  public void testStreamMatVectorWithContents() {
+    final int size = 4;
+    vector.resize(size);
+    long actual = PointerStream.ofMatVector(vector).count();
+    assertEquals("MatVector of size 4 should have 4 stream elements", size, actual);
+  }
+}

--- a/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/cpp/operations/Filter_Contours.vm
+++ b/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/cpp/operations/Filter_Contours.vm
@@ -15,9 +15,10 @@ This creates the C++ OpenCV Filter Contours function
 	 * @param maxVertexCount maximum vertex Count.
 	 * @param minRatio minimum ratio of width to height.
 	 * @param maxRatio maximum ratio of width to height.
+	 * @param angle the minimum and maximum angle of a contour
 	 * @param output vector of filtered contours.
 	 */
-	void $className::#func($step ["inputContours", "minArea", "minPerimeter", "minWidth", "maxWidth", "minHeight", "maxHeight", "solidity", "maxVertexCount", "minVertexCount", "minRatio", "maxRatio", "output"]) {
+	void $className::#func($step ["inputContours", "minArea", "minPerimeter", "minWidth", "maxWidth", "minHeight", "maxHeight", "solidity", "maxVertexCount", "minVertexCount", "minRatio", "maxRatio", "angle", "output"]) {
 		std::vector<cv::Point> hull;
 		output.clear();
 		for (std::vector<cv::Point> contour: inputContours) {
@@ -33,6 +34,8 @@ This creates the C++ OpenCV Filter Contours function
 			if (contour.size() < minVertexCount || contour.size() > maxVertexCount)	continue;
 			double ratio = (double) bb.width / (double) bb.height;
 			if (ratio < minRatio || ratio > maxRatio) continue;
+			double contourAngle = cv::minAreaRect(contour).angle;
+			if (contourAngle < angle[0] || contourAngle > angle[1]) continue;
 			output.push_back(contour);
 		}
 	}

--- a/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/java/operations/Filter_Contours.vm
+++ b/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/java/operations/Filter_Contours.vm
@@ -15,12 +15,13 @@ This creates the java OpenCV Filter Contours function
 	 * @param minVertexCount minimum vertex Count of the contours
 	 * @param maxVertexCount maximum vertex Count
 	 * @param minRatio minimum ratio of width to height
+	 * @param angle the minimum and maximum angle of a contour
 	 * @param maxRatio maximum ratio of width to height
 	 */
 	private void $tMeth.name($step.name())(List<MatOfPoint> inputContours, double minArea,
 		double minPerimeter, double minWidth, double maxWidth, double minHeight, double
 		maxHeight, double[] solidity, double maxVertexCount, double minVertexCount, double
-		minRatio, double maxRatio, List<MatOfPoint> output) {
+		minRatio, double maxRatio, double[] angle, List<MatOfPoint> output) {
 		final MatOfInt hull = new MatOfInt();
 		output.clear();
 		//operation
@@ -45,6 +46,10 @@ This creates the java OpenCV Filter Contours function
 			if (contour.rows() < minVertexCount || contour.rows() > maxVertexCount)	continue;
 			final double ratio = bb.width / (double)bb.height;
 			if (ratio < minRatio || ratio > maxRatio) continue;
+			final MatOfPoint2f copy = new MatOfPoint2f(contour);
+			final RotatedRect rr = Imgproc.minAreaRect(copy);
+			copy.release();
+			if (rr.angle < angle[0] || rr.angle > angle[1]) continue;
 			output.add(contour);
 		}
 	}

--- a/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/python/operations/Filter_Contours.vm
+++ b/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/python/operations/Filter_Contours.vm
@@ -1,7 +1,7 @@
     @staticmethod
     def $tMeth.name($step.name())(input_contours, min_area, min_perimeter, min_width, max_width,
                         min_height, max_height, solidity, max_vertex_count, min_vertex_count,
-                        min_ratio, max_ratio):
+                        min_ratio, max_ratio, angle):
         """Filters out contours that do not meet certain criteria.
         Args:
             input_contours: Contours as a list of numpy.ndarray.
@@ -16,6 +16,7 @@
             max_vertex_count: Maximum vertex Count.
             min_ratio: Minimum ratio of width to height.
             max_ratio: Maximum ratio of width to height.
+            angle: The minimum and maximum allowable angles of a contour.
         Returns:
             Contours as a list of numpy.ndarray.
         """
@@ -39,6 +40,9 @@
                 continue
             ratio = (float)(w) / h
             if (ratio < min_ratio or ratio > max_ratio):
+                continue
+            contourAngle = cv2.minAreaRect(contour).angle
+            if (contourAngle < angle[0] or contourAngle > angle[1]):
                 continue
             output.append(contour)
         return output


### PR DESCRIPTION
Angle is from minAreaRect, and is in the closed range `[-90, 0]`
Rework contours operations to be a bit more functional
Make filter contours a bit more optimized

Add a `LazyInit` class for lazily creating objects, instead of using a bizarre pattern with `Optional`
Add a utility class for streaming Java-fied `std::vector` types such as `MatVector` as Java `Stream` objects. This currently just supports `MatVector`, but can be added to in the future.