### PR TITLE
Fixes #920 java codegen for filter lines

### DIFF
--- a/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/java/operations/Filter_Lines.vm
+++ b/ui/src/main/resources/edu/wpi/grip/ui/codegeneration/java/operations/Filter_Lines.vm
@@ -8,9 +8,10 @@
 	 */
 	private void $tMeth.name($step.name())(List<Line> inputs,double minLength,double[] angle,
 		List<Line> outputs) {
-		outputs = inputs.stream()
+		outputs.clear();
+		outputs.addAll(inputs.stream()
 				.filter(line -> line.lengthSquared() >= Math.pow(minLength,2))
 				.filter(line -> (line.angle() >= angle[0] && line.angle() <= angle[1])
 				|| (line.angle() + 180.0 >= angle[0] && line.angle() + 180.0 <= angle[1]))
-				.collect(Collectors.toList());
+				.collect(Collectors.toList()));
 	}


### PR DESCRIPTION
Original VM template was reassigning the filtered list to the outputs variable
which would have no effect on the contents of the passed-in argument.  Working
pipelines in the GRIP GUI would show zero filtered lines when the generated class
was used.

Altered the template to manipulate the passed-in list object instead, using
`clear()` and `addAll()`.

Note: there doesn't appear to be unit tests for the generated classes, and I
don't have time to write them.  I tested the fix using test cases in our
own FRC project that use the generated class.

[//]: # (Please ensure that the "Allow edits from maintainers" checkbox is checked. Thanks!)
