### PR TITLE
Make previews always fit vertically in the preview area

### DIFF
--- a/ui/src/main/java/edu/wpi/grip/ui/preview/BlobsSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/BlobsSocketPreviewView.java
@@ -83,7 +83,7 @@ public final class BlobsSocketPreviewView extends ImageBasedPreviewView<BlobsRep
       final Mat output = tmp;
       final int numBlobs = blobsReport.getBlobs().size();
       platform.runAsSoonAsPossible(() -> {
-        final Image image = this.imageConverter.convert(output, getImageHeight());
+        final Image image = this.imageConverter.convert(output);
         this.imageView.setImage(image);
         this.infoLabel.setText("Found " + numBlobs + " blobs");
       });

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/ContoursSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/ContoursSocketPreviewView.java
@@ -77,7 +77,7 @@ public final class ContoursSocketPreviewView extends ImageBasedPreviewView<Conto
       final long finalNumContours = numContours;
       final Mat convertInput = tmp;
       platform.runAsSoonAsPossible(() -> {
-        final Image image = this.imageConverter.convert(convertInput, getImageHeight());
+        final Image image = this.imageConverter.convert(convertInput);
         this.imageView.setImage(image);
         this.infoLabel.setText("Found " + finalNumContours + " contours");
       });

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/ImageBasedPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/ImageBasedPreviewView.java
@@ -8,7 +8,6 @@ import edu.wpi.grip.ui.util.ImageConverter;
 import com.google.common.eventbus.Subscribe;
 
 import javafx.application.Platform;
-import javafx.scene.image.ImageView;
 
 import static org.bytedeco.javacpp.opencv_core.CV_8S;
 import static org.bytedeco.javacpp.opencv_core.CV_8U;
@@ -26,9 +25,7 @@ public abstract class ImageBasedPreviewView<T> extends SocketPreviewView<T> {
   /**
    * The view showing the image.
    */
-  protected final ImageView imageView = new ImageView();
-
-  private int imageHeight = 1;
+  protected final ResizableImageView imageView = new ResizableImageView();
 
   /**
    * @param socket An output socket to preview.
@@ -37,13 +34,6 @@ public abstract class ImageBasedPreviewView<T> extends SocketPreviewView<T> {
     super(socket);
     assert Platform.isFxApplicationThread() : "Must be in FX Thread to create this or you will be"
         + " exposing constructor to another thread!";
-  }
-
-  /**
-   * Gets the height of the image to render.
-   */
-  protected final int getImageHeight() {
-    return imageHeight;
   }
 
   /**
@@ -68,14 +58,6 @@ public abstract class ImageBasedPreviewView<T> extends SocketPreviewView<T> {
    */
   @Subscribe
   public final void onRenderEvent(RenderEvent e) {
-    convertImage();
-  }
-
-  /**
-   * Resizes the image based on the given height while preserving the ratio.
-   */
-  public final void resize(int imageHeight) {
-    this.imageHeight = imageHeight;
     convertImage();
   }
 

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/ImageSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/ImageSocketPreviewView.java
@@ -29,7 +29,7 @@ public class ImageSocketPreviewView extends ImageBasedPreviewView<MatWrapper> {
           .filter(ImageBasedPreviewView::isPreviewable)
           .ifPresent(m -> {
             platform.runAsSoonAsPossible(() -> {
-              Image image = imageConverter.convert(m.getCpu(), getImageHeight());
+              Image image = imageConverter.convert(m.getCpu());
               imageView.setImage(image);
             });
           });

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/LinesSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/LinesSocketPreviewView.java
@@ -100,7 +100,7 @@ public final class LinesSocketPreviewView extends ImageBasedPreviewView<LinesRep
       final Mat convertInput = input;
       final int numLines = lines.size();
       platform.runAsSoonAsPossible(() -> {
-        final Image image = this.imageConverter.convert(convertInput, getImageHeight());
+        final Image image = this.imageConverter.convert(convertInput);
         this.imageView.setImage(image);
         this.infoLabel.setText("Found " + numLines + " lines");
       });

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/PreviewsController.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/PreviewsController.java
@@ -18,7 +18,6 @@ import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.HBox;
 
 import javax.inject.Inject;
@@ -34,8 +33,6 @@ import javax.inject.Singleton;
 public class PreviewsController {
 
   @FXML
-  private ScrollPane scrollPane;
-  @FXML
   private HBox previewBox;
 
   @Inject
@@ -45,11 +42,8 @@ public class PreviewsController {
   @Inject
   private SocketPreviewViewFactory previewViewFactory;
 
-  private static final int PREVIEW_PADDING = 50;
-
   @FXML
   private void initialize() {
-    scrollPane.heightProperty().addListener((obs, o, n) -> resizePreviews(n.intValue()));
   }
 
   /**
@@ -131,7 +125,7 @@ public class PreviewsController {
         // When a socket previewed, add a new view, then sort all of the views so they stay ordered
         SocketPreviewView<?> view = previewViewFactory.create(socket);
         if (view instanceof ImageBasedPreviewView) {
-          ((ImageBasedPreviewView) view).resize((int) (previewBox.getHeight()) - PREVIEW_PADDING);
+          ((ImageBasedPreviewView) view).convertImage();
         }
         previews.add(view);
         sortPreviews(previews);
@@ -173,13 +167,6 @@ public class PreviewsController {
         Comparator.comparing(SocketPreviewView::getSocket,
             (OutputSocket<?> a, OutputSocket<?> b) -> compareSockets(a, b, steps, sources));
     FXCollections.sort(previews, comparePreviews);
-  }
-
-  private void resizePreviews(int height) {
-    getPreviews().stream()
-        .filter(p -> p instanceof ImageBasedPreviewView)
-        .map(p -> (ImageBasedPreviewView) p)
-        .forEach(p -> p.resize(height - PREVIEW_PADDING));
   }
 
 }

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/RectangleSocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/RectangleSocketPreviewView.java
@@ -78,7 +78,7 @@ public final class RectangleSocketPreviewView extends ImageBasedPreviewView<Rect
       final Mat convertInput = tmp;
       final int numRegions = rectangles.size();
       platform.runAsSoonAsPossible(() -> {
-        final Image image = this.imageConverter.convert(convertInput, getImageHeight());
+        final Image image = this.imageConverter.convert(convertInput);
         this.imageView.setImage(image);
         this.infoLabel.setText("Found " + numRegions + " regions of interest");
       });

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/ResizableImageView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/ResizableImageView.java
@@ -1,0 +1,109 @@
+package edu.wpi.grip.ui.preview;
+
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyDoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.geometry.Orientation;
+import javafx.scene.image.Image;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundImage;
+import javafx.scene.layout.BackgroundRepeat;
+import javafx.scene.layout.BackgroundSize;
+import javafx.scene.layout.Region;
+
+/**
+ * A custom implementation of an image view that resizes to fit its parent container.
+ */
+public class ResizableImageView extends Region {
+
+  private final ObjectProperty<Image> image = new SimpleObjectProperty<>(this, "image");
+  private final DoubleProperty ratio = new SimpleDoubleProperty(this, "ratio", 1);
+  private static final BackgroundSize size =
+      new BackgroundSize(BackgroundSize.AUTO, BackgroundSize.AUTO, false, false, true, false);
+
+  /**
+   * Creates a new resizable image view.
+   */
+  public ResizableImageView() {
+    super();
+
+    getStyleClass().add("resizable-image");
+
+    image.addListener((obs, old, img) -> {
+      if (img == null) {
+        setBackground(null);
+        ratio.set(1);
+      } else if (img != old) {
+        // Only create a new background object when the image changes
+        // Otherwise we would be creating a new background object for every frame of every preview
+        Background background = createImageBackground(img);
+        setBackground(background);
+        ratio.set(img.getWidth() / img.getHeight());
+        setPrefHeight(img.getHeight());
+        setPrefWidth(USE_COMPUTED_SIZE);
+      }
+    });
+  }
+
+  /**
+   * Creates a background that displays only the given image.
+   *
+   * @param img the image to create the background for
+   */
+  private static Background createImageBackground(Image img) {
+    BackgroundImage backgroundImage = new BackgroundImage(
+        img,
+        BackgroundRepeat.NO_REPEAT,
+        BackgroundRepeat.NO_REPEAT,
+        null,
+        size
+    );
+    return new Background(backgroundImage);
+  }
+
+  public Image getImage() {
+    return image.get();
+  }
+
+  public ObjectProperty<Image> imageProperty() {
+    return image;
+  }
+
+  public void setImage(Image image) {
+    this.image.set(image);
+  }
+
+  public double getRatio() {
+    return ratio.get();
+  }
+
+  public ReadOnlyDoubleProperty ratioProperty() {
+    return ratio;
+  }
+
+  @Override
+  public Orientation getContentBias() {
+    return Orientation.VERTICAL;
+  }
+
+  /**
+   * Computes the width of the displayed image for the given target height, maintaining the image's
+   * intrinsic aspect ratio.
+   *
+   * @param height the target height of the image
+   * @return the width of the image
+   */
+  private double computeImageWidthForHeight(double height) {
+    if (getImage() == null) {
+      return 1;
+    }
+    return height * getRatio();
+  }
+
+  @Override
+  protected double computePrefWidth(double height) {
+    return computeImageWidthForHeight(height);
+  }
+}

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/SocketPreviewView.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/SocketPreviewView.java
@@ -2,8 +2,6 @@ package edu.wpi.grip.ui.preview;
 
 import edu.wpi.grip.core.sockets.OutputSocket;
 
-import javafx.scene.control.TitledPane;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -21,7 +19,6 @@ public abstract class SocketPreviewView<T> extends TitledPane {
 
     this.setText(this.getTitle());
     this.getStyleClass().add("socket-preview");
-    this.setCollapsible(false);
   }
 
   /**

--- a/ui/src/main/java/edu/wpi/grip/ui/preview/TitledPane.java
+++ b/ui/src/main/java/edu/wpi/grip/ui/preview/TitledPane.java
@@ -1,0 +1,68 @@
+package edu.wpi.grip.ui.preview;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.StackPane;
+
+/**
+ * Custom implementation of a titled pane. The JavaFX implementation has a tendency to add a gap
+ * on the sides of image content when resized.
+ */
+public class TitledPane extends BorderPane {
+
+  private final Label label = new Label();
+  private final HBox top = new HBox(label);
+  private final StackPane center = new StackPane();
+
+  private final ObjectProperty<Node> content = new SimpleObjectProperty<>();
+
+  /**
+   * Creates a new titled pane with no text and no content.
+   */
+  public TitledPane() {
+    this.getStyleClass().add("titled-pane");
+    top.getStyleClass().add("title");
+    center.getStyleClass().add("content");
+
+    content.addListener((obs, old, content) -> {
+      if (content == null) {
+        center.getChildren().clear();
+      } else {
+        center.getChildren().setAll(content);
+      }
+    });
+
+    setTop(top);
+    setCenter(center);
+    setMaxHeight(USE_PREF_SIZE);
+  }
+
+  public void setText(String text) {
+    label.setText(text);
+  }
+
+  public String getText() {
+    return label.getText();
+  }
+
+  public StringProperty textProperty() {
+    return label.textProperty();
+  }
+
+  public Node getContent() {
+    return content.get();
+  }
+
+  public ObjectProperty<Node> contentProperty() {
+    return content;
+  }
+
+  public void setContent(Node content) {
+    this.content.set(content);
+  }
+}

--- a/ui/src/main/resources/edu/wpi/grip/ui/preview/Previews.fxml
+++ b/ui/src/main/resources/edu/wpi/grip/ui/preview/Previews.fxml
@@ -8,7 +8,7 @@
       fillWidth="true" maxHeight="Infinity" styleClass="previews">
     <Label styleClass="pane-title" text="Preview" VBox.Vgrow="NEVER" maxWidth="Infinity" />
     <ScrollPane hbarPolicy="AS_NEEDED" vbarPolicy="AS_NEEDED" fitToWidth="false" fitToHeight="true"
-                maxHeight="Infinity" VBox.Vgrow="ALWAYS" minHeight="150" fx:id="scrollPane">
+                maxHeight="Infinity" VBox.Vgrow="ALWAYS" minHeight="150">
         <HBox fx:id="previewBox" />
     </ScrollPane>
 </VBox>


### PR DESCRIPTION
No more previews clipping below the bottom that forced users to scroll up and down to see information displayed below the image (eg contour count)

Reimplement TitledPane and ImageView to get proper behavior. JavaFX `TitledPane` leaves a gap around the image when it's shrunk, and `ImageView`  is atrocious at resizing to fit its parent.

Remove the overloads in `ImageConverter` that take desired height, since the UI is now responsible for doing the resize calculations.

This is a better implementation of #711 and fix for #710

# Screenshots

**Full size previews**
![GRIP Computer Vision Engine | Edited_012](https://user-images.githubusercontent.com/6320992/56761201-d046b580-676a-11e9-97f6-79725a8bf627.png)

**Partially shrunk**
![GRIP Computer Vision Engine | Edited_014](https://user-images.githubusercontent.com/6320992/56761206-d341a600-676a-11e9-8e7e-07441128b619.png)

**Minimum size previews**
![GRIP Computer Vision Engine | Edited_015](https://user-images.githubusercontent.com/6320992/56761210-d5a40000-676a-11e9-9059-1514e66b0e39.png)
