### PR TITLE
Update opencv-installer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath(group = "edu.wpi.first.wpilib.opencv", name = "opencv-installer", version = "2.0.0")
+        classpath(group = "edu.wpi.first.wpilib.opencv", name = "opencv-installer", version = "2.0.1")
         classpath("com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.+")
 
     }

--- a/ui/ui.gradle.kts
+++ b/ui/ui.gradle.kts
@@ -164,8 +164,8 @@ tasks.register("testSharedLib") {
 }
 
 if (project.hasProperty("generation") || project.hasProperty("genonly")) {
-    val platform = Installer.getPlatform()
-    val jniLocation: String = project.properties.getOrDefault("jniLocation", platform.defaultJniLocation()).toString()
+    val defaultLocation = buildDir.resolve("opencv-jni")
+    val jniLocation: String = project.properties.getOrDefault("jniLocation", defaultLocation).toString()
     val jniPath = File(jniLocation).absolutePath
 
     val installOpenCV = tasks.register("installOpenCV") {


### PR DESCRIPTION
Install JNI to `ui/build/opencv-jni` by default. No more permissions issues during JNI install

Fixes the JDK11 azure builds