### PR TITLE
Fix java 14 url to point to always existing version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,6 @@ jobs:
           workingDirectory: ''
           gradleWrapperFile: 'gradlew'
           gradleOptions: '-Xmx3072m'
-          jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'
           publishJUnitResults: true
           tasks: 'check :ui:jpackage -Pheadless=true -Pgeneration -PlogTests -PskipUITests -Pjdk14=..\build\jdk-14 --stacktrace'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
       - script: |
           $ProgressPreference = 'SilentlyContinue'
           mkdir build
-          wget "https://download.java.net/java/early_access/jpackage/1/openjdk-14-jpackage+1-64_linux-x64_bin.tar.gz" -O "build/jdk-14.tar.gz"
+          wget "https://first.wpi.edu/FRC/roborio/jpackage/openjdk-14-ea+28_linux-x64_bin.tar.gz" -O "build/jdk-14.tar.gz"
           sudo mkdir /opt/java
           sudo tar -xzvf build/jdk-14.tar.gz -C /opt/java
         displayName: 'Download JDK 14'
@@ -76,7 +76,7 @@ jobs:
         displayName: 'Download JDK'
       - powershell: |
           $ProgressPreference = 'SilentlyContinue'
-          wget "https://download.java.net/java/early_access/jpackage/1/openjdk-14-jpackage+1-64_windows-x64_bin.zip" -O "build\jdk-14.zip"
+          wget "https://first.wpi.edu/FRC/roborio/jpackage/openjdk-14-ea+28_windows-x64_bin.zip" -O "build\jdk-14.zip"
           Expand-Archive build\jdk-14.zip -DestinationPath build
         displayName: 'Download JDK 14'
       - task: JavaToolInstaller@0
@@ -130,7 +130,7 @@ jobs:
         displayName: 'Download JDK'
       - powershell: |
           $ProgressPreference = 'SilentlyContinue'
-          wget "https://download.java.net/java/early_access/jpackage/1/openjdk-14-jpackage+1-64_windows-x64_bin.zip" -O "build\jdk-14.zip"
+          wget "https://first.wpi.edu/FRC/roborio/jpackage/openjdk-14-ea+28_windows-x64_bin.zip" -O "build\jdk-14.zip"
           Expand-Archive build\jdk-14.zip -DestinationPath build
         displayName: 'Download JDK 14'
       - task: JavaToolInstaller@0
@@ -173,7 +173,7 @@ jobs:
       - script: |
           mkdir build
           wget "https://download.java.net/java/ga/jdk11/openjdk-11_osx-x64_bin.tar.gz" -O "build/jdk.tar.gz"
-          wget "https://download.java.net/java/early_access/jpackage/1/openjdk-14-jpackage+1-64_osx-x64_bin.tar.gz" -O "build/jdk-14.tar.gz"
+          wget "https://first.wpi.edu/FRC/roborio/jpackage/openjdk-14-ea+28_osx-x64_bin.tar.gz" -O "build/jdk-14.tar.gz"
           sudo tar xzvf build/jdk-14.tar.gz -C /Library/Java/JavaVirtualMachines/
           sudo tar xvzf build/jdk.tar.gz -C /Library/Java/JavaVirtualMachines/
           export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home/

--- a/buildSrc/src/main/kotlin/JpackageExec.kt
+++ b/buildSrc/src/main/kotlin/JpackageExec.kt
@@ -234,7 +234,7 @@ open class JpackageExec : DefaultTask() {
             fileAssociations.ifPresent { propsFile ->
                 args.addAll("--file-associations", propsFile.asFile.absolutePath)
             }
-            args.addAll("--package-type", installerType.get())
+            args.addAll("--type", installerType.get())
 
             when (OperatingSystem.current()) {
                 OperatingSystem.WINDOWS -> {


### PR DESCRIPTION
This should mean we no longer need to update the version every time oracle removes one.